### PR TITLE
Add class agnostic fetch node on appfilesystem

### DIFF
--- a/afs-core/src/main/java/com/powsybl/afs/AppFileSystem.java
+++ b/afs-core/src/main/java/com/powsybl/afs/AppFileSystem.java
@@ -122,6 +122,45 @@ public class AppFileSystem implements AutoCloseable {
     }
 
     /**
+     * Retrieve a project node with undefined class
+     * @param nodeId the node Id
+     * @return a typed node
+     */
+    public AbstractNodeBase fetchNode(String nodeId) {
+        Objects.requireNonNull(nodeId);
+
+        NodeInfo projectFileInfo = storage.getNodeInfo(nodeId);
+        NodeInfo parentInfo = storage.getParentNode(projectFileInfo.getId()).orElse(null);
+        while (parentInfo != null && !Project.PSEUDO_CLASS.equals(parentInfo.getPseudoClass())) {
+            parentInfo = storage.getParentNode(parentInfo.getId()).orElse(null);
+        }
+
+        NodeInfo projectInfo = parentInfo;
+        while (projectInfo != null && !Project.PSEUDO_CLASS.equals(projectInfo.getPseudoClass())) {
+            projectInfo = storage.getParentNode(projectInfo.getId()).orElse(null);
+        }
+        Project project = projectInfo != null && Project.PSEUDO_CLASS.equals(projectInfo.getPseudoClass()) ?
+                new Project(new FileCreationContext(projectInfo, storage, this)) : null;
+
+        if (parentInfo == null || project == null) {
+            return createNode(projectFileInfo);
+        }
+
+        ProjectFileCreationContext context = new ProjectFileCreationContext(projectFileInfo, storage, project);
+
+        if (ProjectFolder.PSEUDO_CLASS.equals(projectFileInfo.getPseudoClass())) {
+            return new ProjectFolder(context);
+        }
+
+        ProjectFileExtension extension = data.getProjectFileExtensionByPseudoClass(projectFileInfo.getPseudoClass());
+        if (extension != null) {
+            return extension.createProjectFile(context);
+        }
+        return createNode(projectFileInfo);
+    }
+
+
+    /**
      * Get a project by its ID
      *
      * @param projectId projectID

--- a/afs-core/src/test/java/com/powsybl/afs/AfsBaseTest.java
+++ b/afs-core/src/test/java/com/powsybl/afs/AfsBaseTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import static org.junit.Assert.*;
 
@@ -297,4 +298,41 @@ public class AfsBaseTest {
         assertEquals(project.getFileSystem(), foundProject.getFileSystem());
         assertEquals(project.getCodeVersion(), foundProject.getCodeVersion());
     }
+
+    @Test
+    public void fetchNodeTest() {
+        Folder folder = afs.getRootFolder().createFolder("testFolder");
+        Project project = folder.createProject("test");
+        FooFile createdFile = project.getRootFolder().fileBuilder(FooFileBuilder.class)
+                .withName("foo")
+                .build();
+        ProjectFolder projectFolder = project.getRootFolder().createFolder("testFolder");
+        FooFile nestedFile = projectFolder.fileBuilder(FooFileBuilder.class)
+                .withName("bar")
+                .build();
+
+        BiConsumer<AbstractNodeBase, AbstractNodeBase> checkResult = (source, result) -> {
+            assertNotNull(result);
+            assertEquals(source.getClass(), result.getClass());
+            assertEquals(source.getId(), result.getId());
+            assertEquals(source.getName(), result.getName());
+            assertEquals(source.getName(), result.getName());
+            assertEquals(source.getDescription(), result.getDescription());
+            assertEquals(source.getCreationDate(), result.getCreationDate());
+            assertEquals(source.getModificationDate(), result.getModificationDate());
+            assertEquals(source.getCodeVersion(), result.getCodeVersion());
+
+            if (source instanceof ProjectNode) {
+                assertEquals(((ProjectNode) source).getProject().getId(), ((ProjectNode) result).getProject().getId());
+                assertEquals(((ProjectNode) source).getFileSystem(), ((ProjectNode) result).getFileSystem());
+            }
+        };
+
+        checkResult.accept(project, afs.fetchNode(project.getId()));
+        checkResult.accept(folder, afs.fetchNode(folder.getId()));
+        checkResult.accept(createdFile, afs.fetchNode(createdFile.getId()));
+        checkResult.accept(nestedFile, afs.fetchNode(nestedFile.getId()));
+        checkResult.accept(projectFolder, afs.fetchNode(projectFolder.getId()));
+    }
+
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
Did not find a way to retrieve a node without providing its class.


**What is the new behavior (if this is a feature change)?**
Add a method that fetch a node without this prior information.
