### PR TITLE
Invalidate network on dep changes

### DIFF
--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/VirtualCase.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/VirtualCase.java
@@ -43,6 +43,7 @@ public class VirtualCase extends ProjectFile implements ProjectCase {
         Objects.requireNonNull(aCase);
         setDependencies(CASE_DEPENDENCY_NAME, Collections.singletonList(aCase));
         projectCaseDependency.invalidate();
+        invalidate();
     }
 
     public Optional<ModificationScript> getScript() {
@@ -53,6 +54,7 @@ public class VirtualCase extends ProjectFile implements ProjectCase {
         Objects.requireNonNull(aScript);
         setDependencies(SCRIPT_DEPENDENCY_NAME, Collections.singletonList(aScript));
         modificationScriptDependency.invalidate();
+        invalidate();
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Paul Bui-Quang <paul.buiquang@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Network cache isn't invalidated when dependencies are changed


**What is the new behavior (if this is a feature change)?**
Invalidation occur when dependencies are changed
