### PR TITLE
Add missing GenericScript extension

### DIFF
--- a/afs-ext-base/pom.xml
+++ b/afs-ext-base/pom.xml
@@ -80,6 +80,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/AbstractScript.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/AbstractScript.java
@@ -61,6 +61,7 @@ public abstract class AbstractScript<T extends AbstractScript> extends ProjectFi
             throw new AfsCircularDependencyException();
         }
         orderedDependencyManager.appendDependencies(INCLUDED_SCRIPTS_DEPENDENCY_NAME, Collections.singletonList(genericScript));
+        invalidate();
     }
 
     public void addScript(T includeScript) {
@@ -68,10 +69,12 @@ public abstract class AbstractScript<T extends AbstractScript> extends ProjectFi
             throw new AfsCircularDependencyException();
         }
         orderedDependencyManager.appendDependencies(INCLUDED_SCRIPTS_DEPENDENCY_NAME, Collections.singletonList(includeScript));
+        invalidate();
     }
 
     public void removeScript(String scriptNodeId) {
         orderedDependencyManager.removeDependencies(INCLUDED_SCRIPTS_DEPENDENCY_NAME, Collections.singletonList(scriptNodeId));
+        invalidate();
     }
 
     public void switchIncludedDependencies(int dependencyIndex1, int dependencyIndex2) {

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/GenericScript.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/GenericScript.java
@@ -16,7 +16,8 @@ import com.powsybl.afs.ProjectFileCreationContext;
 public class GenericScript extends AbstractScript<GenericScript> {
     public static final String PSEUDO_CLASS = "genericScript";
     public static final int VERSION = 0;
-    private static final String SCRIPT_CONTENT = "scriptContent";
+    static final String SCRIPT_CONTENT = "scriptContent";
+    static final String SCRIPT_TYPE = "scriptType";
 
     public GenericScript(ProjectFileCreationContext context) {
         super(context, VERSION, SCRIPT_CONTENT);

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/GenericScriptBuilder.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/GenericScriptBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/GenericScriptBuilder.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/GenericScriptBuilder.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ */
+
+package com.powsybl.afs.ext.base;
+
+import com.google.common.io.CharStreams;
+import com.powsybl.afs.AfsException;
+import com.powsybl.afs.ProjectFileBuildContext;
+import com.powsybl.afs.ProjectFileBuilder;
+import com.powsybl.afs.ProjectFileCreationContext;
+import com.powsybl.afs.ext.base.events.ScriptModified;
+import com.powsybl.afs.storage.NodeGenericMetadata;
+import com.powsybl.afs.storage.NodeInfo;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+/**
+ * @author Paul Bui-Quang <paul.buiquang at rte-france.com>
+ */
+public class GenericScriptBuilder implements ProjectFileBuilder<GenericScript> {
+
+    private final ProjectFileBuildContext context;
+
+    private String name;
+
+    private ScriptType type;
+
+    private String content;
+
+    public GenericScriptBuilder(ProjectFileBuildContext context) {
+        this.context = Objects.requireNonNull(context);
+    }
+
+    public GenericScriptBuilder withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public GenericScriptBuilder withType(ScriptType type) {
+        this.type = type;
+        return this;
+    }
+
+    public GenericScriptBuilder withContent(String content) {
+        this.content = content;
+        return this;
+    }
+
+    @Override
+    public GenericScript build() {
+        // check parameters
+        if (name == null) {
+            throw new AfsException("Name is not set");
+        }
+        if (type == null) {
+            throw new AfsException("Script type is not set");
+        }
+        if (content == null) {
+            throw new AfsException("Content is not set");
+        }
+
+        if (context.getStorage().getChildNode(context.getFolderInfo().getId(), name).isPresent()) {
+            throw new AfsException("Parent folder already contains a '" + name + "' node");
+        }
+
+        // create project file
+        NodeInfo info = context.getStorage().createNode(context.getFolderInfo().getId(), name, GenericScript.PSEUDO_CLASS, "", GenericScript.VERSION,
+                new NodeGenericMetadata().setString(GenericScript.SCRIPT_TYPE, type.name()));
+
+        // store script
+        try (Reader reader = new StringReader(content);
+             Writer writer = new OutputStreamWriter(context.getStorage().writeBinaryData(info.getId(), GenericScript.SCRIPT_CONTENT), StandardCharsets.UTF_8)) {
+            CharStreams.copy(reader, writer);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        context.getStorage().setConsistent(info.getId());
+
+        context.getStorage().flush();
+
+        GenericScript genericScript = new GenericScript(new ProjectFileCreationContext(info, context.getStorage(), context.getProject()));
+
+        context.getStorage().getEventsBus().pushEvent(new ScriptModified(info.getId(),
+                context.getFolderInfo().getId(), genericScript.getPath().toString()), ScriptModified.TYPENAME);
+
+        return genericScript;
+    }
+}

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/GenericScriptExtension.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/GenericScriptExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/GenericScriptExtension.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/GenericScriptExtension.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ */
+
+package com.powsybl.afs.ext.base;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.afs.ProjectFileBuildContext;
+import com.powsybl.afs.ProjectFileCreationContext;
+import com.powsybl.afs.ProjectFileExtension;
+
+/**
+ * @author Paul Bui-Quang <paul.buiquang at rte-france.com>
+ */
+@AutoService(ProjectFileExtension.class)
+public class GenericScriptExtension implements ProjectFileExtension<GenericScript, GenericScriptBuilder> {
+    @Override
+    public Class<GenericScript> getProjectFileClass() {
+        return GenericScript.class;
+    }
+
+    @Override
+    public String getProjectFilePseudoClass() {
+        return GenericScript.PSEUDO_CLASS;
+    }
+
+    @Override
+    public Class<GenericScriptBuilder> getProjectFileBuilderClass() {
+        return GenericScriptBuilder.class;
+    }
+
+    @Override
+    public GenericScript createProjectFile(ProjectFileCreationContext context) {
+        return new GenericScript(context);
+    }
+
+    @Override
+    public GenericScriptBuilder createProjectFileBuilder(ProjectFileBuildContext context) {
+        return new GenericScriptBuilder(context);
+    }
+}

--- a/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/ModificationScriptTest.java
+++ b/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/ModificationScriptTest.java
@@ -160,5 +160,10 @@ public class ModificationScriptTest extends AbstractProjectFileTest {
 
         assertThatCode(() -> script.switchIncludedDependencies(0, -1)).isInstanceOf(AfsException.class);
         assertThatCode(() -> script.switchIncludedDependencies(1, 2)).isInstanceOf(AfsException.class);
+
+        assertThatCode(() -> rootFolder.fileBuilder(GenericScriptBuilder.class).build()).isInstanceOf(AfsException.class).hasMessage("Name is not set");
+        assertThatCode(() -> rootFolder.fileBuilder(GenericScriptBuilder.class).withName("foo").build()).isInstanceOf(AfsException.class).hasMessage("Script type is not set");
+        assertThatCode(() -> rootFolder.fileBuilder(GenericScriptBuilder.class).withName("foo").withType(ScriptType.GROOVY).build()).isInstanceOf(AfsException.class).hasMessage("Content is not set");
+        assertThatCode(() -> rootFolder.fileBuilder(GenericScriptBuilder.class).withName("include_script2").withType(ScriptType.GROOVY).withContent("hello").build()).isInstanceOf(AfsException.class).hasMessage("Parent folder already contains a 'include_script2' node");
     }
 }

--- a/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/ModificationScriptTest.java
+++ b/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/ModificationScriptTest.java
@@ -18,8 +18,8 @@ import org.junit.Test;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.*;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.Assert.*;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -38,7 +38,7 @@ public class ModificationScriptTest extends AbstractProjectFileTest {
 
     @Override
     protected List<ProjectFileExtension> getProjectFileExtensions() {
-        return ImmutableList.of(new ModificationScriptExtension());
+        return ImmutableList.of(new ModificationScriptExtension(), new GenericScriptExtension());
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Generic script afs object does not have an associated extension


**What is the new behavior (if this is a feature change)?**
The extension now allows the creation of generic script objects
