### PR TITLE
Remove the compilation of powsybl-core during CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,16 +16,6 @@ jobs:
         with:
           java-version: 1.8
           
-      - name: Checkout powsybl-core
-        uses: actions/checkout@v1
-        with:
-          repository: powsybl/powsybl-core
-          ref: refs/heads/master
-
-      - name: Build powsybl-core with Maven
-        run: mvn --batch-mode -DskipTests install
-        working-directory: ../powsybl-core
-
       - name: Checkout sources
         uses: actions/checkout@v1
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
N/A


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Continuous Integration


**What is the current behavior?** *(You can also link to an open issue here)*
Powsybl-core was build during CI because we depend on snapshot


**What is the new behavior (if this is a feature change)?**
Powsybl-core is not build during CI anymore because we depend on release


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
