### PR TITLE
Remove network cache invalidation on delete

### DIFF
--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ImportedCase.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ImportedCase.java
@@ -87,8 +87,12 @@ public class ImportedCase extends ProjectFile implements ProjectCase {
     @Override
     public void delete() {
         super.delete();
+    }
 
-        // also clean cache
+    @Override
+    protected void invalidate() {
+        super.invalidate();
+
         invalidateNetworkCache();
     }
 

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ImportedCase.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ImportedCase.java
@@ -85,11 +85,6 @@ public class ImportedCase extends ProjectFile implements ProjectCase {
     }
 
     @Override
-    public void delete() {
-        super.delete();
-    }
-
-    @Override
     protected void invalidate() {
         super.invalidate();
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bug fix

**What is the current behavior?** *(You can also link to an open issue here)*
Cache invalidation is done after deletion, which cause an error since the object is deleted and not found on invalidation.


**What is the new behavior (if this is a feature change)?**
Move invalidation of network cache in invalidate general method


