### PR TITLE
Javadoc for groovy only module

### DIFF
--- a/afs-scripting/pom.xml
+++ b/afs-scripting/pom.xml
@@ -21,6 +21,10 @@
     <name>Scripting AFS</name>
     <description>Extensions to use AFS in scripts</description>
 
+    <properties>
+        <groovydoc.classifier>javadoc</groovydoc.classifier>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-parent</artifactId>
-        <version>1</version>
+        <version>2</version>
         <relativePath/>
     </parent>
     <artifactId>powsybl-afs</artifactId>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The javadoc is missing for groovy only module


**What is the new behavior (if this is a feature change)?**
The groovydoc is generated into the expected module javadoc
