### PR TITLE
Add extension ".ts" when archive time-series

### DIFF
--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/AppStorageArchive.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/AppStorageArchive.java
@@ -50,6 +50,8 @@ public class AppStorageArchive {
 
     private static final String DEPENDENCIES = "dependencies";
 
+    private static final String TSEXTENSION = ".ts";
+
     private static class ArchiveDependency {
 
         @JsonProperty("nodeId")
@@ -204,7 +206,7 @@ public class AppStorageArchive {
         Files.createDirectory(timeSeriesDir);
 
         for (TimeSeriesMetadata metadata : storage.getTimeSeriesMetadata(nodeInfo.getId(), timeSeriesNames)) {
-            String timeSeriesFileName = URLEncoder.encode(metadata.getName(), StandardCharsets.UTF_8.name());
+            String timeSeriesFileName = URLEncoder.encode(metadata.getName() + TSEXTENSION, StandardCharsets.UTF_8.name());
             Path timeSeriesNameDir = timeSeriesDir.resolve(timeSeriesFileName);
             Files.createDirectory(timeSeriesNameDir);
 
@@ -427,6 +429,7 @@ public class AppStorageArchive {
                 stream.forEach(timeSeriesNameDir -> {
                     try {
                         String timeSeriesName = URLDecoder.decode(timeSeriesNameDir.getFileName().toString(), StandardCharsets.UTF_8.name());
+                        timeSeriesName = timeSeriesName.substring(0, timeSeriesName.length() - 3);
                         timeSeriesNames.add(timeSeriesName);
                         TimeSeriesMetadata metadata;
                         try (Reader reader = Files.newBufferedReader(timeSeriesNameDir.resolve("metadata.json"), StandardCharsets.UTF_8)) {

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/AppStorageArchive.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/AppStorageArchive.java
@@ -429,7 +429,7 @@ public class AppStorageArchive {
                 stream.forEach(timeSeriesNameDir -> {
                     try {
                         String timeSeriesName = URLDecoder.decode(timeSeriesNameDir.getFileName().toString(), StandardCharsets.UTF_8.name());
-                        timeSeriesName = timeSeriesName.substring(0, timeSeriesName.length() - 3);
+                        timeSeriesName = timeSeriesName.substring(0, timeSeriesName.length() - TSEXTENSION.length());
                         timeSeriesNames.add(timeSeriesName);
                         TimeSeriesMetadata metadata;
                         try (Reader reader = Files.newBufferedReader(timeSeriesNameDir.resolve("metadata.json"), StandardCharsets.UTF_8)) {


### PR DESCRIPTION
Signed-off-by: berthaultval <valentinberthault@outlook.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Some timeseries have a dot at the end of their name. Therefore when we archive Windows delete these dots and when we unarchive  the timeseries are not present because metadata and the name of the folder are different.


**What is the new behavior (if this is a feature change)?**
When we archive the extension ".ts" is added.
