### PR TITLE
Add node ref id in tasks

### DIFF
--- a/afs-core/src/main/java/com/powsybl/afs/LocalTaskMonitor.java
+++ b/afs-core/src/main/java/com/powsybl/afs/LocalTaskMonitor.java
@@ -34,18 +34,22 @@ public class LocalTaskMonitor implements TaskMonitor {
     public Task startTask(ProjectFile projectFile) {
         Objects.requireNonNull(projectFile);
 
-        return startTask(projectFile.getName(), projectFile.getProject());
+        return startTask(projectFile.getName(), projectFile.getProject(), projectFile.getId());
     }
 
     @Override
     public Task startTask(String name, Project project) {
+        return startTask(name, project, null);
+    }
+
+    public Task startTask(String name, Project project, String nodeId) {
         Objects.requireNonNull(name);
         Objects.requireNonNull(project);
 
         lock.lock();
         try {
             revision++;
-            Task task = new Task(name, null, revision, project.getId());
+            Task task = new Task(name, null, revision, project.getId(), nodeId);
             tasks.put(task.getId(), task);
 
             // notification

--- a/afs-core/src/main/java/com/powsybl/afs/TaskMonitor.java
+++ b/afs-core/src/main/java/com/powsybl/afs/TaskMonitor.java
@@ -46,6 +46,9 @@ public interface TaskMonitor extends AutoCloseable {
         @JsonProperty("projectId")
         private final String projectId;
 
+        @JsonProperty("nodeId")
+        private final String nodeId;
+
         @JsonProperty("cancellable")
         private boolean cancellable;
 
@@ -53,7 +56,15 @@ public interface TaskMonitor extends AutoCloseable {
                     String message,
                     long revision,
                     String projectId) {
-            this(name, message, revision, projectId, false);
+            this(name, message, revision, projectId, null, false);
+        }
+
+        public Task(String name,
+                    String message,
+                    long revision,
+                    String projectId,
+                    String nodeId) {
+            this(name, message, revision, projectId, nodeId, false);
         }
 
         @JsonCreator
@@ -61,12 +72,14 @@ public interface TaskMonitor extends AutoCloseable {
                     @JsonProperty("message") String message,
                     @JsonProperty("revision") long revision,
                     @JsonProperty("projectId") String projectId,
+                    @JsonProperty("nodeId") String nodeId,
                     @JsonProperty("cancellable") boolean cancellable) {
             id = UUID.randomUUID();
             this.name = Objects.requireNonNull(name);
             this.message = message;
             this.revision = revision;
             this.projectId = Objects.requireNonNull(projectId);
+            this.nodeId = nodeId;
             this.cancellable = cancellable;
         }
 
@@ -77,6 +90,7 @@ public interface TaskMonitor extends AutoCloseable {
             message = other.message;
             revision = other.revision;
             projectId = other.projectId;
+            nodeId = other.nodeId;
             cancellable = other.cancellable;
         }
 
@@ -114,6 +128,10 @@ public interface TaskMonitor extends AutoCloseable {
 
         String getProjectId() {
             return projectId;
+        }
+
+        public String getNodeId() {
+            return nodeId;
         }
 
         @Override

--- a/afs-core/src/main/java/com/powsybl/afs/TaskMonitor.java
+++ b/afs-core/src/main/java/com/powsybl/afs/TaskMonitor.java
@@ -136,7 +136,7 @@ public interface TaskMonitor extends AutoCloseable {
 
         @Override
         public int hashCode() {
-            return Objects.hash(id, name, message, revision, projectId);
+            return Objects.hash(id, name, message, revision, nodeId, projectId);
         }
 
         @Override
@@ -147,6 +147,7 @@ public interface TaskMonitor extends AutoCloseable {
                         && name.equals(other.name)
                         && Objects.equals(message, other.message)
                         && revision == other.revision
+                        && nodeId.equals(other.nodeId)
                         && projectId.equals(other.projectId);
             }
             return false;

--- a/afs-core/src/test/java/com/powsybl/afs/LocalTaskMonitorTest.java
+++ b/afs-core/src/test/java/com/powsybl/afs/LocalTaskMonitorTest.java
@@ -68,6 +68,7 @@ public class LocalTaskMonitorTest extends AbstractProjectFileTest {
             TaskMonitor.Task task = monitor.startTask(foo);
             assertEquals("foo", task.getName());
             assertEquals(1, events.size());
+            assertEquals(foo.getId(), task.getNodeId());
             assertEquals(new StartTaskEvent(task.getId(), 1L, "foo"), events.pop());
 
             assertEquals(1L, monitor.takeSnapshot(null).getRevision());

--- a/afs-core/src/test/java/com/powsybl/afs/LocalTaskMonitorTest.java
+++ b/afs-core/src/test/java/com/powsybl/afs/LocalTaskMonitorTest.java
@@ -48,6 +48,9 @@ public class LocalTaskMonitorTest extends AbstractProjectFileTest {
                 .withName("foo")
                 .build();
 
+        TaskMonitor.Task legacyTask = new TaskMonitor.Task("test", "test", 1L, test.getId());
+        assertNull(legacyTask.getNodeId());
+
         try (TaskMonitor monitor = new LocalTaskMonitor()) {
             Deque<TaskEvent> events = new ArrayDeque<>();
             TaskListener listener = new TaskListener() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
task is unaware of the afs node source that lead to its creation


**What is the new behavior (if this is a feature change)?**
when task are created from a project file, the id of the node is attached to the task
