### PR TITLE
Add missing dependency removed event on node deletion

### DIFF
--- a/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/MapDbAppStorage.java
+++ b/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/MapDbAppStorage.java
@@ -536,6 +536,8 @@ public class MapDbAppStorage extends AbstractAppStorage {
             for (NamedLink linkToRemove : linksToRemove) {
                 removeFromList(dependencyNodesMap, otherNodeUuid, linkToRemove);
                 dependencyNodesByNameMap.remove(new NamedLink(otherNodeUuid, linkToRemove.getName()));
+                pushEvent(new DependencyRemoved(linkToRemove.getNodeUuid().toString(), linkToRemove.getName()), APPSTORAGE_DEPENDENCY_TOPIC);
+                pushEvent(new BackwardDependencyRemoved(nodeUuid.toString(), linkToRemove.getName()), APPSTORAGE_DEPENDENCY_TOPIC);
             }
         }
 
@@ -543,6 +545,8 @@ public class MapDbAppStorage extends AbstractAppStorage {
         for (NamedLink link : dependencyNodesMap.get(nodeUuid)) {
             dependencyNodesByNameMap.remove(new NamedLink(nodeUuid, link.getName()));
             removeFromList(backwardDependencyNodesMap, link.getNodeUuid(), nodeUuid);
+            pushEvent(new DependencyRemoved(nodeUuid.toString(), link.getName()), APPSTORAGE_DEPENDENCY_TOPIC);
+            pushEvent(new BackwardDependencyRemoved(link.getNodeUuid().toString(), link.getName()), APPSTORAGE_DEPENDENCY_TOPIC);
         }
         dependencyNodesMap.remove(nodeUuid);
         return parentNodeUuid;

--- a/afs-storage-api/src/test/java/com/powsybl/afs/storage/AbstractAppStorageTest.java
+++ b/afs-storage-api/src/test/java/com/powsybl/afs/storage/AbstractAppStorageTest.java
@@ -276,7 +276,10 @@ public abstract class AbstractAppStorageTest {
         storage.flush();
 
         // check event
-        assertEventStack(new NodeRemoved(testDataInfo.getId(), testFolderInfo.getId()));
+        assertEventStack(
+                new DependencyRemoved(testDataInfo.getId(), "mylink"),
+                new BackwardDependencyRemoved(testData2Info.getId(), "mylink"),
+                new NodeRemoved(testDataInfo.getId(), testFolderInfo.getId()));
 
         // check test folder children have been correctly updated
         assertEquals(2, storage.getChildNodes(testFolderInfo.getId()).size());
@@ -586,7 +589,7 @@ public abstract class AbstractAppStorageTest {
 
         checkMetadataEquality(metadata, node.getGenericMetadata());
 
-        discardEvents(18);
+        discardEvents(22);
 
         storage.setMetadata(node.getId(), cloneMetadata(metadata));
         storage.flush();


### PR DESCRIPTION
Signed-off-by: Paul Bui-Quang <paul.buiquang@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When a node is deleted, there is no event indicating to other object that the dependency to that object was also removed.
This prevent from correctly updating objects for this loss

**What is the new behavior (if this is a feature change)?**
The corresponding events to the dependencies deletions are added.
