### PR TITLE
archive keep result time series

### DIFF
--- a/afs-core/src/main/java/com/powsybl/afs/AbstractNodeBase.java
+++ b/afs-core/src/main/java/com/powsybl/afs/AbstractNodeBase.java
@@ -177,12 +177,12 @@ public abstract class AbstractNodeBase<F> {
         return childNodes.stream().filter(nodeInfo -> !nodeInfo.getId().equals(getId())).anyMatch(nodeInfo -> nodeInfo.getName().equals(name));
     }
 
-    public void archive(Path dir, boolean useZip, boolean archiveDependencies, Map<String, List<String>> outputBlackList, Map<String, Boolean> keepTs) {
+    public void archive(Path dir, boolean useZip, boolean archiveDependencies, Map<String, List<String>> outputBlackList, List<String> removeTs) {
 
         Objects.requireNonNull(dir);
 
         try {
-            new AppStorageArchive(storage).archive(info.getId(), dir, archiveDependencies, outputBlackList, keepTs);
+            new AppStorageArchive(storage).archive(info.getId(), dir, archiveDependencies, outputBlackList, removeTs);
             if (useZip) {
                 Path zipPath = dir.getParent().resolve(dir.getFileName() + ".zip");
                 Utils.zip(dir, zipPath, true);
@@ -190,6 +190,10 @@ public abstract class AbstractNodeBase<F> {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    public void archive(Path dir, boolean useZip, boolean archiveDependencies, Map<String, List<String>> outputBlackList) {
+        archive(dir, useZip, archiveDependencies, outputBlackList, Collections.emptyList());
     }
 
     public void unarchive(Path dir, boolean isZipped) {
@@ -216,12 +220,16 @@ public abstract class AbstractNodeBase<F> {
         }
     }
 
-    public void archive(Path dir, Map<String, List<String>> outputBlackList, Map<String, Boolean> keepTs) {
+    public void archive(Path dir, Map<String, List<String>> outputBlackList, List<String> keepTs) {
         archive(dir, false, false, outputBlackList, keepTs);
     }
 
+    public void archive(Path dir, Map<String, List<String>> outputBlackList) {
+        archive(dir, false, false, outputBlackList, Collections.emptyList());
+    }
+
     public void archive(Path dir) {
-        archive(dir, false, false, Collections.emptyMap(), Collections.emptyMap());
+        archive(dir, false, false, Collections.emptyMap(), Collections.emptyList());
     }
 
     public void unarchive(Path dir) {

--- a/afs-core/src/main/java/com/powsybl/afs/AbstractNodeBase.java
+++ b/afs-core/src/main/java/com/powsybl/afs/AbstractNodeBase.java
@@ -177,12 +177,12 @@ public abstract class AbstractNodeBase<F> {
         return childNodes.stream().filter(nodeInfo -> !nodeInfo.getId().equals(getId())).anyMatch(nodeInfo -> nodeInfo.getName().equals(name));
     }
 
-    public void archive(Path dir, boolean useZip, boolean archiveDependencies, Map<String, List<String>> outputBlackList) {
+    public void archive(Path dir, boolean useZip, boolean archiveDependencies, Map<String, List<String>> outputBlackList, Map<String, Boolean> keepTs) {
 
         Objects.requireNonNull(dir);
 
         try {
-            new AppStorageArchive(storage).archive(info.getId(), dir, archiveDependencies, outputBlackList);
+            new AppStorageArchive(storage).archive(info.getId(), dir, archiveDependencies, outputBlackList, keepTs);
             if (useZip) {
                 Path zipPath = dir.getParent().resolve(dir.getFileName() + ".zip");
                 Utils.zip(dir, zipPath, true);
@@ -216,12 +216,12 @@ public abstract class AbstractNodeBase<F> {
         }
     }
 
-    public void archive(Path dir, Map<String, List<String>> outputBlackList) {
-        archive(dir, false, false, outputBlackList);
+    public void archive(Path dir, Map<String, List<String>> outputBlackList, Map<String, Boolean> keepTs) {
+        archive(dir, false, false, outputBlackList, keepTs);
     }
 
     public void archive(Path dir) {
-        archive(dir, false, false, Collections.emptyMap());
+        archive(dir, false, false, Collections.emptyMap(), Collections.emptyMap());
     }
 
     public void unarchive(Path dir) {

--- a/afs-core/src/main/java/com/powsybl/afs/AppFileSystemTool.java
+++ b/afs-core/src/main/java/com/powsybl/afs/AppFileSystemTool.java
@@ -20,10 +20,7 @@ import org.apache.commons.cli.Options;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -205,14 +202,13 @@ public class AppFileSystemTool implements Tool {
             boolean archiveDependencies = line.hasOption(DEPENDENCIES);
             boolean deleteResult = line.hasOption(DELETE_RESULT_OPTNAME);
             Map<String, List<String>> outputBlackList = new HashMap<>();
-            Map<String, Boolean> keepTs = new HashMap<>();
+            List<String> keepTs = new ArrayList<>();
             if (deleteResult) {
                 outputBlackList = PROJECT_FILE_EXECUTION.getServices().stream()
                         .collect(Collectors.toMap(ProjectFileExtension::getProjectFilePseudoClass,
                                 ProjectFileExtension::getOutputList));
-                keepTs = PROJECT_FILE_EXECUTION.getServices().stream()
-                        .collect(Collectors.toMap(ProjectFileExtension::getProjectFilePseudoClass,
-                                ProjectFileExtension::keepTSWhenArchive));
+                keepTs = PROJECT_FILE_EXECUTION.getServices().stream().filter(ProjectFileExtension::removeTSWhenArchive).map(ProjectFileExtension::getProjectFilePseudoClass)
+                        .collect(Collectors.toList());
             }
             fs.getRootFolder().archive(dir, mustZip, archiveDependencies, outputBlackList, keepTs);
         }

--- a/afs-core/src/main/java/com/powsybl/afs/AppFileSystemTool.java
+++ b/afs-core/src/main/java/com/powsybl/afs/AppFileSystemTool.java
@@ -205,12 +205,16 @@ public class AppFileSystemTool implements Tool {
             boolean archiveDependencies = line.hasOption(DEPENDENCIES);
             boolean deleteResult = line.hasOption(DELETE_RESULT_OPTNAME);
             Map<String, List<String>> outputBlackList = new HashMap<>();
+            Map<String, Boolean> keepTs = new HashMap<>();
             if (deleteResult) {
                 outputBlackList = PROJECT_FILE_EXECUTION.getServices().stream()
                         .collect(Collectors.toMap(ProjectFileExtension::getProjectFilePseudoClass,
                                 ProjectFileExtension::getOutputList));
+                keepTs = PROJECT_FILE_EXECUTION.getServices().stream()
+                        .collect(Collectors.toMap(ProjectFileExtension::getProjectFilePseudoClass,
+                                ProjectFileExtension::keepTSWhenArchive));
             }
-            fs.getRootFolder().archive(dir, mustZip, archiveDependencies, outputBlackList);
+            fs.getRootFolder().archive(dir, mustZip, archiveDependencies, outputBlackList, keepTs);
         }
     }
 

--- a/afs-core/src/main/java/com/powsybl/afs/ProjectFileExtension.java
+++ b/afs-core/src/main/java/com/powsybl/afs/ProjectFileExtension.java
@@ -87,4 +87,11 @@ public interface ProjectFileExtension<T extends ProjectFile, U extends ProjectFi
     default List<String> getOutputList() {
         return Collections.emptyList();
     }
+
+    /**
+     * return list of output file in time-series folder
+     */
+    default Boolean keepTSWhenArchive() {
+        return true;
+    }
 }

--- a/afs-core/src/main/java/com/powsybl/afs/ProjectFileExtension.java
+++ b/afs-core/src/main/java/com/powsybl/afs/ProjectFileExtension.java
@@ -91,7 +91,7 @@ public interface ProjectFileExtension<T extends ProjectFile, U extends ProjectFi
     /**
      * return list of output file in time-series folder
      */
-    default Boolean keepTSWhenArchive() {
-        return true;
+    default boolean removeTSWhenArchive() {
+        return false;
     }
 }

--- a/afs-core/src/test/java/com/powsybl/afs/AfsBaseTest.java
+++ b/afs-core/src/test/java/com/powsybl/afs/AfsBaseTest.java
@@ -326,15 +326,15 @@ public class AfsBaseTest {
         ProjectFolder rootFolder = project.getRootFolder();
         ProjectFolder dir1 = rootFolder.createFolder("dir1");
         NodeInfo metrix = storage.createNode(dir1.getId(), "metrix", "METRIX", "", 0, new NodeGenericMetadata());
-        NodeInfo timeSerieVituel = storage.createNode(dir1.getId(), "timeSerieVituel", "TSV", "", 0, new NodeGenericMetadata());
+        NodeInfo timeSerieVirtuel = storage.createNode(dir1.getId(), "timeSerieVirtuel", "TSV", "", 0, new NodeGenericMetadata());
 
         RegularTimeSeriesIndex index = RegularTimeSeriesIndex.create(Interval.parse("2015-01-01T00:00:00Z/2015-01-01T01:45:00Z"),
                 Duration.ofMinutes(15));
         storage.createTimeSeries(metrix.getId(), new TimeSeriesMetadata("ts1", TimeSeriesDataType.STRING, index));
-        storage.createTimeSeries(timeSerieVituel.getId(), new TimeSeriesMetadata("ts2", TimeSeriesDataType.DOUBLE, index));
+        storage.createTimeSeries(timeSerieVirtuel.getId(), new TimeSeriesMetadata("ts2", TimeSeriesDataType.DOUBLE, index));
 
         storage.setConsistent(metrix.getId());
-        storage.setConsistent(timeSerieVituel.getId());
+        storage.setConsistent(timeSerieVirtuel.getId());
         Path rootDir = fileSystem.getPath("/root");
         Files.createDirectory(rootDir);
         Files.createDirectory(rootDir.resolve("test"));
@@ -342,7 +342,7 @@ public class AfsBaseTest {
         deleteTSPseudoClass.add("METRIX");
         dir1.archive(rootDir.resolve("test"), false, true, new HashMap<>(), deleteTSPseudoClass);
         Path child1 = rootDir.resolve("test/" + dir1.getId() + "/children/" + metrix.getId() + "/time-series/ts1.ts");
-        Path child2 = rootDir.resolve("test/" + dir1.getId() + "/children/" + timeSerieVituel.getId() + "/time-series/ts2.ts");
+        Path child2 = rootDir.resolve("test/" + dir1.getId() + "/children/" + timeSerieVirtuel.getId() + "/time-series/ts2.ts");
         assertTrue(Files.exists(child2));
         assertTrue(Files.notExists(child1));
     }

--- a/afs-core/src/test/java/com/powsybl/afs/AfsBaseTest.java
+++ b/afs-core/src/test/java/com/powsybl/afs/AfsBaseTest.java
@@ -341,8 +341,8 @@ public class AfsBaseTest {
         List<String> deleteTSPseudoClass = new ArrayList<>();
         deleteTSPseudoClass.add("METRIX");
         dir1.archive(rootDir.resolve("test"), false, true, new HashMap<>(), deleteTSPseudoClass);
-        Path child1 = rootDir.resolve("test/"+dir1.getId()+"/children/"+metrix.getId()+"/time-series/ts1.ts");
-        Path child2 = rootDir.resolve("test/"+dir1.getId()+"/children/"+timeSerieVituel.getId()+"/time-series/ts2.ts");
+        Path child1 = rootDir.resolve("test/" + dir1.getId() + "/children/" + metrix.getId() + "/time-series/ts1.ts");
+        Path child2 = rootDir.resolve("test/" + dir1.getId()+"/children/"+timeSerieVituel.getId() + "/time-series/ts2.ts");
         assertTrue(Files.exists(child2));
         assertTrue(Files.notExists(child1));
     }

--- a/afs-core/src/test/java/com/powsybl/afs/AfsBaseTest.java
+++ b/afs-core/src/test/java/com/powsybl/afs/AfsBaseTest.java
@@ -17,10 +17,14 @@ import com.powsybl.afs.storage.NodeGenericMetadata;
 import com.powsybl.afs.storage.NodeInfo;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.iidm.network.NetworkFactoryService;
+import com.powsybl.timeseries.RegularTimeSeriesIndex;
+import com.powsybl.timeseries.TimeSeriesDataType;
+import com.powsybl.timeseries.TimeSeriesMetadata;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.threeten.extra.Interval;
 
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -29,6 +33,7 @@ import java.io.Writer;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.*;
 import java.util.function.BiConsumer;
 
@@ -241,7 +246,7 @@ public class AfsBaseTest {
         Path rootDir = fileSystem.getPath("/root");
         Files.createDirectory(rootDir);
         Files.createDirectory(rootDir.resolve("test"));
-        dir1.archive(rootDir.resolve("test"), true, false, new HashMap<>(), new HashMap<>());
+        dir1.archive(rootDir.resolve("test"), true, false, new HashMap<>());
         child = rootDir.resolve("test.zip");
         assertTrue(Files.exists(child));
 
@@ -267,7 +272,7 @@ public class AfsBaseTest {
         List<String> deleteExtension = new ArrayList<>();
         deleteExtension.add("data1");
         blackList.put("projectFolder", deleteExtension);
-        dir1.archive(rootDir, blackList, new HashMap<>());
+        dir1.archive(rootDir, blackList);
         child = rootDir.resolve(dir1.getId());
         assertTrue(Files.exists(child));
 
@@ -300,7 +305,7 @@ public class AfsBaseTest {
         Path rootDir = fileSystem.getPath("/root");
         Files.createDirectory(rootDir);
         Files.createDirectory(rootDir.resolve("test"));
-        dir1.archive(rootDir.resolve("test"), true, true, new HashMap<>(), new HashMap<>());
+        dir1.archive(rootDir.resolve("test"), true, true, new HashMap<>());
         Path child = rootDir.resolve("test.zip");
         assertTrue(Files.exists(child));
 
@@ -313,6 +318,33 @@ public class AfsBaseTest {
         assertEquals("data", listNode.get(0).getName());
         assertEquals("dir2", listNode.get(1).getName());
         assertEquals("data2", storage.getChildNodes(listNode.get(1).getId()).get(0).getName());
+    }
+
+    @Test
+    public void archiveAndUnarchiveTestRemoveTS() throws IOException {
+        Project project = afs.getRootFolder().createProject("test");
+        ProjectFolder rootFolder = project.getRootFolder();
+        ProjectFolder dir1 = rootFolder.createFolder("dir1");
+        NodeInfo metrix = storage.createNode(dir1.getId(), "metrix", "METRIX", "", 0, new NodeGenericMetadata());
+        NodeInfo timeSerieVituel = storage.createNode(dir1.getId(), "timeSerieVituel", "TSV", "", 0, new NodeGenericMetadata());
+
+        RegularTimeSeriesIndex index = RegularTimeSeriesIndex.create(Interval.parse("2015-01-01T00:00:00Z/2015-01-01T01:45:00Z"),
+                Duration.ofMinutes(15));
+        storage.createTimeSeries(metrix.getId(), new TimeSeriesMetadata("ts1", TimeSeriesDataType.STRING, index));
+        storage.createTimeSeries(timeSerieVituel.getId(), new TimeSeriesMetadata("ts2", TimeSeriesDataType.DOUBLE, index));
+
+        storage.setConsistent(metrix.getId());
+        storage.setConsistent(timeSerieVituel.getId());
+        Path rootDir = fileSystem.getPath("/root");
+        Files.createDirectory(rootDir);
+        Files.createDirectory(rootDir.resolve("test"));
+        List<String> deleteTSPseudoClass = new ArrayList<>();
+        deleteTSPseudoClass.add("METRIX");
+        dir1.archive(rootDir.resolve("test"), false, true, new HashMap<>(), deleteTSPseudoClass);
+        Path child1 = rootDir.resolve("test/"+dir1.getId()+"/children/"+metrix.getId()+"/time-series/ts1.ts");
+        Path child2 = rootDir.resolve("test/"+dir1.getId()+"/children/"+timeSerieVituel.getId()+"/time-series/ts2.ts");
+        assertTrue(Files.exists(child2));
+        assertTrue(Files.notExists(child1));
     }
 
     @Test
@@ -347,7 +379,7 @@ public class AfsBaseTest {
         Path rootDir = fileSystem.getPath("/root");
         Files.createDirectory(rootDir);
         Files.createDirectory(rootDir.resolve("test"));
-        dir1.archive(rootDir.resolve("test"), true, true, new HashMap<>(), new HashMap<>());
+        dir1.archive(rootDir.resolve("test"), true, true, new HashMap<>());
         Path child = rootDir.resolve("test.zip");
         assertTrue(Files.exists(child));
 
@@ -396,7 +428,7 @@ public class AfsBaseTest {
         Path rootDir = fileSystem.getPath("/root");
         Files.createDirectory(rootDir);
         Files.createDirectory(rootDir.resolve("test"));
-        dir1.archive(rootDir.resolve("test"), true, true, new HashMap<>(), new HashMap<>());
+        dir1.archive(rootDir.resolve("test"), true, true, new HashMap<>());
         Path child = rootDir.resolve("test.zip");
         assertTrue(Files.exists(child));
 

--- a/afs-core/src/test/java/com/powsybl/afs/AfsBaseTest.java
+++ b/afs-core/src/test/java/com/powsybl/afs/AfsBaseTest.java
@@ -342,7 +342,7 @@ public class AfsBaseTest {
         deleteTSPseudoClass.add("METRIX");
         dir1.archive(rootDir.resolve("test"), false, true, new HashMap<>(), deleteTSPseudoClass);
         Path child1 = rootDir.resolve("test/" + dir1.getId() + "/children/" + metrix.getId() + "/time-series/ts1.ts");
-        Path child2 = rootDir.resolve("test/" + dir1.getId() + "/children/"+timeSerieVituel.getId() + "/time-series/ts2.ts");
+        Path child2 = rootDir.resolve("test/" + dir1.getId() + "/children/" + timeSerieVituel.getId() + "/time-series/ts2.ts");
         assertTrue(Files.exists(child2));
         assertTrue(Files.notExists(child1));
     }

--- a/afs-core/src/test/java/com/powsybl/afs/AfsBaseTest.java
+++ b/afs-core/src/test/java/com/powsybl/afs/AfsBaseTest.java
@@ -342,7 +342,7 @@ public class AfsBaseTest {
         deleteTSPseudoClass.add("METRIX");
         dir1.archive(rootDir.resolve("test"), false, true, new HashMap<>(), deleteTSPseudoClass);
         Path child1 = rootDir.resolve("test/" + dir1.getId() + "/children/" + metrix.getId() + "/time-series/ts1.ts");
-        Path child2 = rootDir.resolve("test/" + dir1.getId()+"/children/"+timeSerieVituel.getId() + "/time-series/ts2.ts");
+        Path child2 = rootDir.resolve("test/" + dir1.getId() + "/children/"+timeSerieVituel.getId() + "/time-series/ts2.ts");
         assertTrue(Files.exists(child2));
         assertTrue(Files.notExists(child1));
     }

--- a/afs-core/src/test/java/com/powsybl/afs/AfsBaseTest.java
+++ b/afs-core/src/test/java/com/powsybl/afs/AfsBaseTest.java
@@ -326,15 +326,15 @@ public class AfsBaseTest {
         ProjectFolder rootFolder = project.getRootFolder();
         ProjectFolder dir1 = rootFolder.createFolder("dir1");
         NodeInfo metrix = storage.createNode(dir1.getId(), "metrix", "METRIX", "", 0, new NodeGenericMetadata());
-        NodeInfo timeSerieVirtuel = storage.createNode(dir1.getId(), "timeSerieVirtuel", "TSV", "", 0, new NodeGenericMetadata());
+        NodeInfo virtualTimeSeries = storage.createNode(dir1.getId(), "virtualTimeSeries", "TSV", "", 0, new NodeGenericMetadata());
 
         RegularTimeSeriesIndex index = RegularTimeSeriesIndex.create(Interval.parse("2015-01-01T00:00:00Z/2015-01-01T01:45:00Z"),
                 Duration.ofMinutes(15));
         storage.createTimeSeries(metrix.getId(), new TimeSeriesMetadata("ts1", TimeSeriesDataType.STRING, index));
-        storage.createTimeSeries(timeSerieVirtuel.getId(), new TimeSeriesMetadata("ts2", TimeSeriesDataType.DOUBLE, index));
+        storage.createTimeSeries(virtualTimeSeries.getId(), new TimeSeriesMetadata("ts2", TimeSeriesDataType.DOUBLE, index));
 
         storage.setConsistent(metrix.getId());
-        storage.setConsistent(timeSerieVirtuel.getId());
+        storage.setConsistent(virtualTimeSeries.getId());
         Path rootDir = fileSystem.getPath("/root");
         Files.createDirectory(rootDir);
         Files.createDirectory(rootDir.resolve("test"));
@@ -342,7 +342,7 @@ public class AfsBaseTest {
         deleteTSPseudoClass.add("METRIX");
         dir1.archive(rootDir.resolve("test"), false, true, new HashMap<>(), deleteTSPseudoClass);
         Path child1 = rootDir.resolve("test/" + dir1.getId() + "/children/" + metrix.getId() + "/time-series/ts1.ts");
-        Path child2 = rootDir.resolve("test/" + dir1.getId() + "/children/" + timeSerieVirtuel.getId() + "/time-series/ts2.ts");
+        Path child2 = rootDir.resolve("test/" + dir1.getId() + "/children/" + virtualTimeSeries.getId() + "/time-series/ts2.ts");
         assertTrue(Files.exists(child2));
         assertTrue(Files.notExists(child1));
     }

--- a/afs-core/src/test/java/com/powsybl/afs/AfsBaseTest.java
+++ b/afs-core/src/test/java/com/powsybl/afs/AfsBaseTest.java
@@ -241,7 +241,7 @@ public class AfsBaseTest {
         Path rootDir = fileSystem.getPath("/root");
         Files.createDirectory(rootDir);
         Files.createDirectory(rootDir.resolve("test"));
-        dir1.archive(rootDir.resolve("test"), true, false, new HashMap<>());
+        dir1.archive(rootDir.resolve("test"), true, false, new HashMap<>(), new HashMap<>());
         child = rootDir.resolve("test.zip");
         assertTrue(Files.exists(child));
 
@@ -267,7 +267,7 @@ public class AfsBaseTest {
         List<String> deleteExtension = new ArrayList<>();
         deleteExtension.add("data1");
         blackList.put("projectFolder", deleteExtension);
-        dir1.archive(rootDir, blackList);
+        dir1.archive(rootDir, blackList, new HashMap<>());
         child = rootDir.resolve(dir1.getId());
         assertTrue(Files.exists(child));
 
@@ -300,7 +300,7 @@ public class AfsBaseTest {
         Path rootDir = fileSystem.getPath("/root");
         Files.createDirectory(rootDir);
         Files.createDirectory(rootDir.resolve("test"));
-        dir1.archive(rootDir.resolve("test"), true, true, new HashMap<>());
+        dir1.archive(rootDir.resolve("test"), true, true, new HashMap<>(), new HashMap<>());
         Path child = rootDir.resolve("test.zip");
         assertTrue(Files.exists(child));
 
@@ -347,7 +347,7 @@ public class AfsBaseTest {
         Path rootDir = fileSystem.getPath("/root");
         Files.createDirectory(rootDir);
         Files.createDirectory(rootDir.resolve("test"));
-        dir1.archive(rootDir.resolve("test"), true, true, new HashMap<>());
+        dir1.archive(rootDir.resolve("test"), true, true, new HashMap<>(), new HashMap<>());
         Path child = rootDir.resolve("test.zip");
         assertTrue(Files.exists(child));
 
@@ -396,7 +396,7 @@ public class AfsBaseTest {
         Path rootDir = fileSystem.getPath("/root");
         Files.createDirectory(rootDir);
         Files.createDirectory(rootDir.resolve("test"));
-        dir1.archive(rootDir.resolve("test"), true, true, new HashMap<>());
+        dir1.archive(rootDir.resolve("test"), true, true, new HashMap<>(), new HashMap<>());
         Path child = rootDir.resolve("test.zip");
         assertTrue(Files.exists(child));
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/AppStorageArchive.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/AppStorageArchive.java
@@ -110,19 +110,26 @@ public class AppStorageArchive {
 
         private final Map<String, List<String>> outputBlackList = new HashMap<>();
 
+        private final Map<String, Boolean> keepTs = new HashMap<>();
+
         private final boolean archiveDependencies;
 
         public ArchiveContext(boolean archiveDependencies) {
             this.archiveDependencies = archiveDependencies;
         }
 
-        public ArchiveContext(boolean archiveDependencies, Map<String, List<String>> outputBlackList) {
+        public ArchiveContext(boolean archiveDependencies, Map<String, List<String>> outputBlackList, Map<String, Boolean> keepTs) {
             this.archiveDependencies = archiveDependencies;
             this.outputBlackList.putAll(outputBlackList);
+            this.keepTs.putAll(keepTs);
         }
 
         public Map<String, List<String>> getOutputBlackList() {
             return ImmutableMap.copyOf(outputBlackList);
+        }
+
+        public Map<String, Boolean> getkeepTSList() {
+            return ImmutableMap.copyOf(keepTs);
         }
 
         public List<String> getIdListObject() {
@@ -194,7 +201,7 @@ public class AppStorageArchive {
         }
     }
 
-    private void writeTimeSeries(NodeInfo nodeInfo, Path nodeDir) throws IOException {
+    private void writeTimeSeries(NodeInfo nodeInfo, Path nodeDir, ArchiveContext archiveDependencies) throws IOException {
         Set<String> timeSeriesNames = storage.getTimeSeriesNames(nodeInfo.getId());
         if (timeSeriesNames.isEmpty()) {
             return;
@@ -206,34 +213,36 @@ public class AppStorageArchive {
         Files.createDirectory(timeSeriesDir);
 
         for (TimeSeriesMetadata metadata : storage.getTimeSeriesMetadata(nodeInfo.getId(), timeSeriesNames)) {
-            String timeSeriesFileName = URLEncoder.encode(metadata.getName() + TSEXTENSION, StandardCharsets.UTF_8.name());
-            Path timeSeriesNameDir = timeSeriesDir.resolve(timeSeriesFileName);
-            Files.createDirectory(timeSeriesNameDir);
+            if (archiveDependencies.getkeepTSList().isEmpty() || archiveDependencies.getkeepTSList().get(nodeInfo.getPseudoClass())) {
+                String timeSeriesFileName = URLEncoder.encode(metadata.getName() + TSEXTENSION, StandardCharsets.UTF_8.name());
+                Path timeSeriesNameDir = timeSeriesDir.resolve(timeSeriesFileName);
+                Files.createDirectory(timeSeriesNameDir);
 
-            // write metadata
-            try (Writer writer = Files.newBufferedWriter(timeSeriesNameDir.resolve("metadata.json"), StandardCharsets.UTF_8)) {
-                objectWriter.writeValue(writer, metadata);
-            }
+                // write metadata
+                try (Writer writer = Files.newBufferedWriter(timeSeriesNameDir.resolve("metadata.json"), StandardCharsets.UTF_8)) {
+                    objectWriter.writeValue(writer, metadata);
+                }
 
-            // write chunks for each version
-            for (int version : storage.getTimeSeriesDataVersions(nodeInfo.getId(), metadata.getName())) {
-                switch (metadata.getDataType()) {
-                    case DOUBLE:
-                        List<DoubleDataChunk> doubleChunks = storage.getDoubleTimeSeriesData(nodeInfo.getId(), Collections.singleton(metadata.getName()), version).get(metadata.getName());
-                        try (Writer writer = new OutputStreamWriter(new GZIPOutputStream(Files.newOutputStream(timeSeriesNameDir.resolve("chunks-" + version + ".json.gz"))), StandardCharsets.UTF_8)) {
-                            objectWriter.writeValue(writer, doubleChunks);
-                        }
-                        break;
+                // write chunks for each version
+                for (int version : storage.getTimeSeriesDataVersions(nodeInfo.getId(), metadata.getName())) {
+                    switch (metadata.getDataType()) {
+                        case DOUBLE:
+                            List<DoubleDataChunk> doubleChunks = storage.getDoubleTimeSeriesData(nodeInfo.getId(), Collections.singleton(metadata.getName()), version).get(metadata.getName());
+                            try (Writer writer = new OutputStreamWriter(new GZIPOutputStream(Files.newOutputStream(timeSeriesNameDir.resolve("chunks-" + version + ".json.gz"))), StandardCharsets.UTF_8)) {
+                                objectWriter.writeValue(writer, doubleChunks);
+                            }
+                            break;
 
-                    case STRING:
-                        List<StringDataChunk> stringChunks = storage.getStringTimeSeriesData(nodeInfo.getId(), Collections.singleton(metadata.getName()), version).get(metadata.getName());
-                        try (Writer writer = new OutputStreamWriter(new GZIPOutputStream(Files.newOutputStream(timeSeriesNameDir.resolve("chunks-" + version + ".json.gz"))), StandardCharsets.UTF_8)) {
-                            objectWriter.writeValue(writer, stringChunks);
-                        }
-                        break;
+                        case STRING:
+                            List<StringDataChunk> stringChunks = storage.getStringTimeSeriesData(nodeInfo.getId(), Collections.singleton(metadata.getName()), version).get(metadata.getName());
+                            try (Writer writer = new OutputStreamWriter(new GZIPOutputStream(Files.newOutputStream(timeSeriesNameDir.resolve("chunks-" + version + ".json.gz"))), StandardCharsets.UTF_8)) {
+                                objectWriter.writeValue(writer, stringChunks);
+                            }
+                            break;
 
-                    default:
-                        throw new AssertionError("Unsupported data type " + metadata.getDataType());
+                        default:
+                            throw new AssertionError("Unsupported data type " + metadata.getDataType());
+                    }
                 }
             }
         }
@@ -280,12 +289,12 @@ public class AppStorageArchive {
         }
     }
 
-    public void archive(String nodeId, Path parentDir, boolean archiveDependencies, Map<String, List<String>> outputBlackList) {
+    public void archive(String nodeId, Path parentDir, boolean archiveDependencies, Map<String, List<String>> outputBlackList, Map<String, Boolean> keepTs) {
         Objects.requireNonNull(nodeId);
         Objects.requireNonNull(parentDir);
 
         try {
-            archive(storage.getNodeInfo(nodeId), parentDir, new ArchiveContext(archiveDependencies, outputBlackList));
+            archive(storage.getNodeInfo(nodeId), parentDir, new ArchiveContext(archiveDependencies, outputBlackList, keepTs));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -316,7 +325,7 @@ public class AppStorageArchive {
 
             writeData(nodeInfo, nodeDir, archiveDependencies);
 
-            writeTimeSeries(nodeInfo, nodeDir);
+            writeTimeSeries(nodeInfo, nodeDir, archiveDependencies);
 
             archiveChildren(nodeInfo, nodeDir, archiveDependencies);
 


### PR DESCRIPTION
Signed-off-by: berthaultval <valentinberthault@outlook.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
When you archive with the option to delete the results, the time series are archived with the metrix and the multi-situation.


**What is the new behavior (if this is a feature change)?**
when you archive with the option to delete the results, the time series aren't archived with the metrix and the multi-situation

