### PR TITLE
Remove node event connection (listener) when fetching dependencies

### DIFF
--- a/afs-core/src/main/java/com/powsybl/afs/AppFileSystem.java
+++ b/afs-core/src/main/java/com/powsybl/afs/AppFileSystem.java
@@ -133,7 +133,7 @@ public class AppFileSystem implements AutoCloseable {
      * @throws AfsStorageException if the node not found
      * @return a typed node
      */
-    public AbstractNodeBase fetchNode(String nodeId) {
+    public AbstractNodeBase fetchNode(String nodeId, boolean connected) {
         Objects.requireNonNull(nodeId);
 
         NodeInfo projectFileInfo = storage.getNodeInfo(nodeId);
@@ -153,7 +153,7 @@ public class AppFileSystem implements AutoCloseable {
             return createNode(projectFileInfo);
         }
 
-        ProjectFileCreationContext context = new ProjectFileCreationContext(projectFileInfo, storage, project);
+        ProjectFileCreationContext context = new ProjectFileCreationContext(projectFileInfo, storage, project, connected);
 
         if (ProjectFolder.PSEUDO_CLASS.equals(projectFileInfo.getPseudoClass())) {
             return new ProjectFolder(context);
@@ -164,6 +164,15 @@ public class AppFileSystem implements AutoCloseable {
             return extension.createProjectFile(context);
         }
         return createNode(projectFileInfo);
+    }
+
+    /**
+     * Retrieve a project node with undefined class
+     * @param nodeId the node Id
+     * @return a typed node
+     */
+    public AbstractNodeBase fetchNode(String nodeId) {
+        return fetchNode(nodeId, true);
     }
 
 

--- a/afs-core/src/main/java/com/powsybl/afs/OrderedDependencyManager.java
+++ b/afs-core/src/main/java/com/powsybl/afs/OrderedDependencyManager.java
@@ -87,7 +87,7 @@ public class OrderedDependencyManager {
 
     private List<ProjectDependency<ProjectNode>> getDependencyCache() {
         if (dependencyCache == null) {
-            dependencyCache = projectFile.getDependencies();
+            dependencyCache = projectFile.getDependencies(true);
         }
         return dependencyCache;
     }

--- a/afs-core/src/main/java/com/powsybl/afs/Project.java
+++ b/afs-core/src/main/java/com/powsybl/afs/Project.java
@@ -39,11 +39,7 @@ public class Project extends File {
 
     ProjectNode createProjectNode(NodeInfo nodeInfo) {
         Objects.requireNonNull(nodeInfo);
-        if (ProjectFolder.PSEUDO_CLASS.equals(nodeInfo.getPseudoClass())) {
-            return createProjectFolder(nodeInfo);
-        } else {
-            return createProjectFile(nodeInfo);
-        }
+        return createProjectNode(nodeInfo, true);
     }
 
     ProjectNode createProjectNode(NodeInfo nodeInfo, boolean connected) {
@@ -56,14 +52,7 @@ public class Project extends File {
     }
 
     ProjectFile createProjectFile(NodeInfo nodeInfo) {
-        Objects.requireNonNull(nodeInfo);
-        ProjectFileCreationContext context = new ProjectFileCreationContext(nodeInfo, storage, this);
-        ProjectFileExtension extension = fileSystem.getData().getProjectFileExtensionByPseudoClass(nodeInfo.getPseudoClass());
-        if (extension != null) {
-            return extension.createProjectFile(context);
-        } else {
-            return new UnknownProjectFile(context);
-        }
+        return createProjectFile(nodeInfo, true);
     }
 
     ProjectFile createProjectFile(NodeInfo nodeInfo, boolean connected) {

--- a/afs-core/src/main/java/com/powsybl/afs/Project.java
+++ b/afs-core/src/main/java/com/powsybl/afs/Project.java
@@ -46,9 +46,29 @@ public class Project extends File {
         }
     }
 
+    ProjectNode createProjectNode(NodeInfo nodeInfo, boolean connected) {
+        Objects.requireNonNull(nodeInfo);
+        if (ProjectFolder.PSEUDO_CLASS.equals(nodeInfo.getPseudoClass())) {
+            return createProjectFolder(nodeInfo);
+        } else {
+            return createProjectFile(nodeInfo, connected);
+        }
+    }
+
     ProjectFile createProjectFile(NodeInfo nodeInfo) {
         Objects.requireNonNull(nodeInfo);
         ProjectFileCreationContext context = new ProjectFileCreationContext(nodeInfo, storage, this);
+        ProjectFileExtension extension = fileSystem.getData().getProjectFileExtensionByPseudoClass(nodeInfo.getPseudoClass());
+        if (extension != null) {
+            return extension.createProjectFile(context);
+        } else {
+            return new UnknownProjectFile(context);
+        }
+    }
+
+    ProjectFile createProjectFile(NodeInfo nodeInfo, boolean connected) {
+        Objects.requireNonNull(nodeInfo);
+        ProjectFileCreationContext context = new ProjectFileCreationContext(nodeInfo, storage, this, connected);
         ProjectFileExtension extension = fileSystem.getData().getProjectFileExtensionByPseudoClass(nodeInfo.getPseudoClass());
         if (extension != null) {
             return extension.createProjectFile(context);

--- a/afs-core/src/main/java/com/powsybl/afs/ProjectFile.java
+++ b/afs-core/src/main/java/com/powsybl/afs/ProjectFile.java
@@ -57,10 +57,7 @@ public class ProjectFile extends ProjectNode {
     }
 
     public List<ProjectDependency<ProjectNode>> getDependencies() {
-        return storage.getDependencies(info.getId())
-                .stream()
-                .map(dependency -> new ProjectDependency<>(dependency.getName(), project.createProjectNode(dependency.getNodeInfo(), false)))
-                .collect(Collectors.toList());
+        return getDependencies(false);
     }
 
     public List<ProjectDependency<ProjectNode>> getDependencies(boolean connected) {

--- a/afs-core/src/main/java/com/powsybl/afs/ProjectFile.java
+++ b/afs-core/src/main/java/com/powsybl/afs/ProjectFile.java
@@ -46,7 +46,9 @@ public class ProjectFile extends ProjectNode {
 
     protected ProjectFile(ProjectFileCreationContext context, int codeVersion) {
         super(context, codeVersion, true);
-        storage.getEventsBus().addListener(l);
+        if (context.isConnected()) {
+            storage.getEventsBus().addListener(l);
+        }
     }
 
     @Override
@@ -57,7 +59,7 @@ public class ProjectFile extends ProjectNode {
     public List<ProjectDependency<ProjectNode>> getDependencies() {
         return storage.getDependencies(info.getId())
                 .stream()
-                .map(dependency -> new ProjectDependency<>(dependency.getName(), project.createProjectNode(dependency.getNodeInfo())))
+                .map(dependency -> new ProjectDependency<>(dependency.getName(), project.createProjectNode(dependency.getNodeInfo(), false)))
                 .collect(Collectors.toList());
     }
 
@@ -90,7 +92,7 @@ public class ProjectFile extends ProjectNode {
         Objects.requireNonNull(name);
         Objects.requireNonNull(nodeClass);
         return storage.getDependencies(info.getId(), name).stream()
-                .map(project::createProjectNode)
+                .map(nodeInfo -> project.createProjectNode(nodeInfo, false))
                 .filter(dependencyNode -> nodeClass.isAssignableFrom(dependencyNode.getClass()))
                 .map(nodeClass::cast)
                 .collect(Collectors.toList());

--- a/afs-core/src/main/java/com/powsybl/afs/ProjectFile.java
+++ b/afs-core/src/main/java/com/powsybl/afs/ProjectFile.java
@@ -63,6 +63,13 @@ public class ProjectFile extends ProjectNode {
                 .collect(Collectors.toList());
     }
 
+    public List<ProjectDependency<ProjectNode>> getDependencies(boolean connected) {
+        return storage.getDependencies(info.getId())
+                .stream()
+                .map(dependency -> new ProjectDependency<>(dependency.getName(), project.createProjectNode(dependency.getNodeInfo(), connected)))
+                .collect(Collectors.toList());
+    }
+
     public void setDependencies(String name, List<ProjectNode> projectNodes) {
         Objects.requireNonNull(name);
         Objects.requireNonNull(projectNodes);

--- a/afs-core/src/main/java/com/powsybl/afs/ProjectFileCreationContext.java
+++ b/afs-core/src/main/java/com/powsybl/afs/ProjectFileCreationContext.java
@@ -16,14 +16,25 @@ import java.util.Objects;
  */
 public class ProjectFileCreationContext extends ProjectFileContext {
 
+    private final boolean connected;
+
     private final NodeInfo info;
 
     public ProjectFileCreationContext(NodeInfo info, AppStorage storage, Project project) {
+        this(info, storage, project, true);
+    }
+
+    public ProjectFileCreationContext(NodeInfo info, AppStorage storage, Project project, boolean connected) {
         super(storage, project);
         this.info = Objects.requireNonNull(info);
+        this.connected = connected;
     }
 
     public NodeInfo getInfo() {
         return info;
+    }
+
+    public boolean isConnected() {
+        return connected;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
When manipulating afs object, a listener is always added. In our cases this is unwanted, especially when browsing large collection of objects. This can cause a very large listener count that needlessly using cpu time.


**What is the new behavior (if this is a feature change)?**
We can instanciate afs object without connecting them to the event system. When fetching an object dependencies, this is now the default behavior.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
