### PR TITLE
Set findService to public

### DIFF
--- a/afs-core/src/main/java/com/powsybl/afs/AppData.java
+++ b/afs-core/src/main/java/com/powsybl/afs/AppData.java
@@ -296,7 +296,7 @@ public class AppData implements AutoCloseable {
      * @param remoteStorage if {@code true}, tries to get a remote implementation first.
      * @throws AfsException if no service implementation is found.
      */
-    <U> U findService(Class<U> serviceClass, boolean remoteStorage) {
+    public <U> U findService(Class<U> serviceClass, boolean remoteStorage) {
         loadServices();
         U service = null;
         if (remoteStorage) {


### PR DESCRIPTION
Signed-off-by: Paul Bui-Quang <paul.buiquang@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
refacto


**What is the current behavior?** *(You can also link to an open issue here)*
we cannot acces AppData::findService outside of a Node. But there is a need for global services that need access to service extension of appadata.


**What is the new behavior (if this is a feature change)?**
Allow access to appdata service extension from other object than afs nodes.


