### PR TITLE
Fix cassandra data node OutputStream potential overlap

### DIFF
--- a/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
+++ b/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
@@ -965,6 +965,12 @@ public class CassandraAppStorage extends AbstractAppStorage {
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
+
+            // at first write clear previous data to prevent just overlapping on a potential previous data of greater length
+            if (chunkNum == 0) {
+                removeData(nodeUuid.toString(), name);
+            }
+
             getSession().execute(insertInto(NODE_DATA)
                     .value(ID, nodeUuid)
                     .value(NAME, name)

--- a/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraDataSplitTest.java
+++ b/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraDataSplitTest.java
@@ -48,6 +48,7 @@ public class CassandraDataSplitTest {
         InputStream is = storage.readBinaryData(nodeInfo.getId(), "a").orElse(null);
         assertNotNull(is);
         assertEquals("aaaaaaaaaabbbbbbbbbbcccccccccc", new String(ByteStreams.toByteArray(is), StandardCharsets.UTF_8));
+        is.close();
 
         try (OutputStream os = storage.writeBinaryData(nodeInfo.getId(), "a")) {
             byte[] bytes = "xaaaaaaaaa".getBytes(StandardCharsets.UTF_8);
@@ -60,6 +61,7 @@ public class CassandraDataSplitTest {
         InputStream is2 = storage.readBinaryData(nodeInfo.getId(), "a").orElse(null);
         assertNotNull(is2);
         assertEquals("xaaaaaaaaa", new String(ByteStreams.toByteArray(is2), StandardCharsets.UTF_8));
+        is2.close();
 
         assertTrue(storage.removeData(nodeInfo.getId(), "a"));
         assertTrue(storage.getDataNames(nodeInfo.getId()).isEmpty());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When using `CassandraAppStorage.writeBinaryData` we receive a `CassandraAppStorage.BinaryDataOutputStream`. I guess it should be intended that when writting on this outputstream the previous data is cleared.
This is not the case since if previous data were larger (with a chunk count greater than the chunk count of the new data), it would result in corrupted data as the reading of this data node would include the new data plus the last chunk not overlapped from the previous data.


**What is the new behavior (if this is a feature change)?**
The data is removed at first write.

**Other information**:
Also (not fixed in this PR), the chunk size is not enforced if the write buffer length used with this outputstream is greater than the chunk size. For instance:
```
String nodeId = "someId";
String dataNodeName = "somedataname";
byte[] data = new byte[N]; // where N is greater than chunk size
Arrays.fill(data, (byte)0);
try(BinaryDataOutputStream os = new BinaryDataOutputStream(nodeId, dataNodeName))  {
  os.write(data); // will call os.write(data, 0, data.length)
}
```
will result in one only chunk written to database instead of the proper chunk count expected. 
Usually the OutputStream is wrapped in an other one that buffers the data way under the size of the configured chunk size, but this is no guarantee.