### PR TITLE
Enforce chunk size in cassandra data output stream

### DIFF
--- a/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
+++ b/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
@@ -1005,10 +1005,7 @@ public class CassandraAppStorage extends AbstractAppStorage {
                 int chunkOffset = off;
                 long writtenLen = 0;
                 while (writtenLen < len) {
-                    long chunkLen = config.getBinaryDataChunkSize() - count;
-                    if (len - writtenLen < chunkLen) {
-                        chunkLen = len - writtenLen;
-                    }
+                    long chunkLen = Math.min(config.getBinaryDataChunkSize() - count, len - writtenLen);
                     gzos.write(b, chunkOffset, (int) chunkLen);
                     count += chunkLen;
                     writtenLen += chunkLen;

--- a/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
+++ b/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
@@ -1009,7 +1009,7 @@ public class CassandraAppStorage extends AbstractAppStorage {
                     if (len - chunkOffset < config.getBinaryDataChunkSize()) {
                         chunkLen = len - chunkOffset;
                     }
-                    gzos.write(Arrays.copyOfRange(b, chunkOffset, chunkOffset + chunkLen));
+                    gzos.write(b, chunkOffset, chunkLen);
                     count += chunkLen;
                     executeIfNecessary();
                     chunkCount += 1;

--- a/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraDataSplitTest.java
+++ b/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraDataSplitTest.java
@@ -94,6 +94,6 @@ public class CassandraDataSplitTest {
                 .and(eq(NAME, "a")));
         Row firstRow = resultSet.one();
         assertNotNull(firstRow);
-        assertEquals(new Integer(4), firstRow.get(0, Integer.class));
+        assertEquals(4, firstRow.get(0, Integer.class).intValue());
     }
 }

--- a/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraDataSplitTest.java
+++ b/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraDataSplitTest.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.afs.cassandra;
 
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
 import com.google.common.io.ByteStreams;
 import com.powsybl.afs.storage.InMemoryEventsBus;
 import com.powsybl.afs.storage.NodeGenericMetadata;
@@ -19,7 +21,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
+import static com.powsybl.afs.cassandra.CassandraConstants.*;
 import static org.junit.Assert.*;
 
 /**
@@ -32,7 +38,8 @@ public class CassandraDataSplitTest {
 
     @Test
     public void test() throws IOException {
-        CassandraAppStorage storage = new CassandraAppStorage("test", () -> new CassandraTestContext(cassandraCQLUnit),
+        CassandraTestContext cassandraTestContext = new CassandraTestContext(cassandraCQLUnit);
+        CassandraAppStorage storage = new CassandraAppStorage("test", () -> cassandraTestContext,
                 new CassandraAppStorageConfig().setBinaryDataChunkSize(10), new InMemoryEventsBus());
         NodeInfo rootNodeId = storage.createRootNodeIfNotExists("test", "folder");
         NodeInfo nodeInfo = storage.createNode(rootNodeId.getId(), "test1", "folder", "", 0, new NodeGenericMetadata());
@@ -66,5 +73,27 @@ public class CassandraDataSplitTest {
         assertTrue(storage.removeData(nodeInfo.getId(), "a"));
         assertTrue(storage.getDataNames(nodeInfo.getId()).isEmpty());
         assertFalse(storage.readBinaryData(nodeInfo.getId(), "a").isPresent());
+
+        try (OutputStream os = storage.writeBinaryData(nodeInfo.getId(), "a")) {
+            byte[] bytes = "aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd".getBytes(StandardCharsets.UTF_8);
+            os.write(bytes, 0, 5);
+            os.write(bytes, 5, 10);
+            os.write(bytes, 15, 4);
+            os.write(bytes, 19, 3);
+            os.write(bytes, 22, 18);
+        }
+        storage.flush();
+
+        InputStream is3 = storage.readBinaryData(nodeInfo.getId(), "a").orElse(null);
+        assertNotNull(is3);
+        assertEquals("aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd", new String(ByteStreams.toByteArray(is3), StandardCharsets.UTF_8));
+        is3.close();
+
+        ResultSet resultSet = cassandraTestContext.getSession().execute(select(CHUNKS_COUNT).from(NODE_DATA)
+                .where(eq(ID, UUID.fromString(nodeInfo.getId())))
+                .and(eq(NAME, "a")));
+        Row firstRow = resultSet.one();
+        assertNotNull(firstRow);
+        assertEquals(new Integer(4), firstRow.get(0, Integer.class));
     }
 }


### PR DESCRIPTION
Signed-off-by: Paul Bui-Quang <paul.buiquang@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Also (not fixed in this PR), the chunk size is not enforced if the write buffer length used with this outputstream is greater than the chunk size.
For instance:
```
String nodeId = "someId";
String dataNodeName = "somedataname";
byte[] data = new byte[N]; // where N is greater than chunk size
Arrays.fill(data, (byte)0);
try(BinaryDataOutputStream os = new BinaryDataOutputStream(nodeId, dataNodeName))  {
  os.write(data); // will call os.write(data, 0, data.length)
}
```
will result in one only chunk written to database instead of the proper chunk count expected.
Usually the OutputStream is wrapped in an other one that buffers the data way under the size of the configured chunk size, but this is no guarantee.


**What is the new behavior (if this is a feature change)?**
The data is splitted accordingly.
