### PR TITLE
Remove ifnotexist when inserting node_data_name

### DIFF
--- a/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
+++ b/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
@@ -1027,7 +1027,6 @@ public class CassandraAppStorage extends AbstractAppStorage {
 
             // update data names
             getSession().execute(insertInto(NODE_DATA_NAMES)
-                    .ifNotExists()
                     .value(ID, nodeUuid)
                     .value(NAME, name));
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Since https://github.com/powsybl/powsybl-afs/pull/55, the data names are removed before any new write to the data output stream.
It happens that the recreation of the data name at the end, protected with ifNotExists, does not pick up consistently the prior deletion, and therefore sometimes does not recreate the data name.


**What is the new behavior (if this is a feature change)?**
Now the data name is always created (removing the ifNotExists clause since the data name is always deleted before).
Also, the Insert#ifNotExists is stated to impact performance, so performance should also be improved.
