### PR TITLE
[afs-spring-server] Back to springfox v2.9.2, v2.10.5 is broken

### DIFF
--- a/afs-spring-server/src/main/java/com/powsybl/afs/server/StorageSwaggerConfig.java
+++ b/afs-spring-server/src/main/java/com/powsybl/afs/server/StorageSwaggerConfig.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.afs.server;
 
+import com.google.common.base.Predicate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.ApiInfoBuilder;
@@ -13,12 +14,14 @@ import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2WebMvc;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
-import java.util.function.Predicate;
+import static com.google.common.base.Predicates.and;
+import static com.google.common.base.Predicates.not;
+import static springfox.documentation.builders.PathSelectors.regex;
 
 @Configuration
-@EnableSwagger2WebMvc
+@EnableSwagger2
 public class StorageSwaggerConfig {
     @Bean
     public Docket produceApi() {
@@ -42,6 +45,7 @@ public class StorageSwaggerConfig {
     // Only select apis that matches the given Predicates.
     private Predicate<String> paths() {
         // Match all paths except /error
-        return input -> input.matches("/rest/afs/" + StorageServer.API_VERSION + ".*") && !input.matches("/error.*");
+        return and(regex("/rest/afs/" + StorageServer.API_VERSION + ".*"),
+                not(regex("/error.*")));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <resteasy.version>3.1.4.Final</resteasy.version>
         <shrinkwrap-resolver.version>2.2.6</shrinkwrap-resolver.version>
         <slf4j.version>1.7.22</slf4j.version>
-        <springfox.version>2.10.5</springfox.version>
+        <springfox.version>2.9.2</springfox.version>
         <springboot.version>2.2.13.RELEASE</springboot.version>
         <swaggerjaxrs.version>1.5.16</swaggerjaxrs.version>
         <tyrus.version>1.13.1</tyrus.version>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Bug fix

**What is the current behavior?** *(You can also link to an open issue here)*

swagger-ui does not show up in third party projects using powsybl-afs-spring-server

**What is the new behavior (if this is a feature change)?**

swagger-ui shows up correctly

