### PR TITLE
use ServiceLoader.load with the current classloader instead of the context classloader

### DIFF
--- a/afs-ws/afs-ws-server/src/main/java/com/powsybl/afs/ws/server/AppStorageApplication.java
+++ b/afs-ws/afs-ws-server/src/main/java/com/powsybl/afs/ws/server/AppStorageApplication.java
@@ -29,7 +29,7 @@ public class AppStorageApplication extends Application {
     private static final Logger LOGGER = LoggerFactory.getLogger(AppStorageApplication.class);
 
     public AppStorageApplication() {
-        ServiceLoader<SwaggerConfigExtension> swaggerConfigExtensionsIterator = ServiceLoader.load(SwaggerConfigExtension.class);
+        ServiceLoader<SwaggerConfigExtension> swaggerConfigExtensionsIterator = ServiceLoader.load(SwaggerConfigExtension.class, AppStorageApplication.class.getClassLoader());
         ArrayList<SwaggerConfigExtension> swaggerConfigExtensions = Lists.newArrayList(swaggerConfigExtensionsIterator.iterator());
         initSwaggerConfig(swaggerConfigExtensions);
     }


### PR DESCRIPTION
The context classloader can be the wrong one (and ServiceLoader.load returns an empty list)
when you are calling ServiceLoader.load in the ForkJoinPool.commonPool() (or any other thread pool)
and you have your classes in another classloader than the AppClassLoader (=system classloader).
This is the case when using a springboot fat jar, or when deploying the code in a war in an application
server, or when using mvn exec:java

Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
https://github.com/powsybl/powsybl-core/pull/1727
