### PR TITLE
Fix data updated events in cassandra implementation

### DIFF
--- a/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
+++ b/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
@@ -1035,6 +1035,8 @@ public class CassandraAppStorage extends AbstractAppStorage {
             getSession().execute(insertInto(NODE_DATA_NAMES)
                     .value(ID, nodeUuid)
                     .value(NAME, name));
+
+            pushEvent(new NodeDataUpdated(nodeUuid.toString(), name), APPSTORAGE_NODE_TOPIC);
         }
     }
 
@@ -1044,7 +1046,6 @@ public class CassandraAppStorage extends AbstractAppStorage {
         Objects.requireNonNull(name);
         // flush buffer to keep change order
         changeBuffer.flush();
-        pushEvent(new NodeDataUpdated(nodeId, name), APPSTORAGE_NODE_TOPIC);
         return new BinaryDataOutputStream(nodeUuid, name);
     }
 

--- a/afs-storage-api/src/test/java/com/powsybl/afs/storage/AbstractAppStorageTest.java
+++ b/afs-storage-api/src/test/java/com/powsybl/afs/storage/AbstractAppStorageTest.java
@@ -202,6 +202,10 @@ public abstract class AbstractAppStorageTest {
         DataSource ds1 = new AppStorageDataSource(storage, testFolderInfo.getId(), testFolderInfo.getName());
         try (Writer writer = new OutputStreamWriter(storage.writeBinaryData(testFolderInfo.getId(), "testData1"), StandardCharsets.UTF_8)) {
             writer.write("Content for testData1");
+
+            //Event must not be sent before stream is closed: should still be empty for now
+            storage.flush();
+            assertEventStack();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Bug

**What is the current behavior?** *(You can also link to an open issue here)*

In `CassandraAppStorage`, when updating a node's data, the corresponding event is sent at the start of writing instead of being sent when writing is done.

**What is the new behavior (if this is a feature change)?**

`NodeDataUpdated` events are sent when writing is finished.
