### PR TITLE
Fixes cassandra "get parent" behaviour

### DIFF
--- a/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
+++ b/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
@@ -378,7 +378,7 @@ public class CassandraAppStorage extends AbstractAppStorage {
     private String getNodeName(UUID nodeUuid) {
         Objects.requireNonNull(nodeUuid);
         ResultSet resultSet = getSession().execute(select(NAME).from(CHILDREN_BY_NAME_AND_CLASS)
-                                                                         .where(eq(ID, nodeUuid)));
+            .where(eq(ID, nodeUuid)));
         Row row = resultSet.one();
         if (row == null) {
             throw createNodeNotFoundException(nodeUuid);
@@ -720,16 +720,14 @@ public class CassandraAppStorage extends AbstractAppStorage {
     }
 
     private UUID getParentNodeUuid(UUID nodeUuid) {
-        ResultSet resultSet = getSession().execute(select(PARENT_ID, CHILD_CONSISTENT).from(CHILDREN_BY_NAME_AND_CLASS)
+        ResultSet resultSet = getSession().execute(select(PARENT_ID)
+                .from(CHILDREN_BY_NAME_AND_CLASS)
                 .where(eq(ID, nodeUuid)));
         Row row = resultSet.one();
         if (row == null) {
             throw createNodeNotFoundException(nodeUuid);
         }
-        if (isConsistentBackwardCompatible(row, 1)) {
-            return row.getUUID(0);
-        }
-        return null;
+        return row.getUUID(0);
     }
 
     @Override
@@ -1432,7 +1430,7 @@ public class CassandraAppStorage extends AbstractAppStorage {
         UUID nodeUuid = checkNodeId(nodeId);
         Set<NodeInfo> backwardDependencies = new HashSet<>();
         ResultSet resultSet = getSession().execute(select(FROM_ID).from(BACKWARD_DEPENDENCIES)
-                                                                          .where(eq(TO_ID, nodeUuid)));
+                                                                  .where(eq(TO_ID, nodeUuid)));
         for (Row row : resultSet) {
             try {
                 backwardDependencies.add(getNodeInfo(row.getUUID(0)));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Bug fix

**What is the current behavior?** *(You can also link to an open issue here)*

In `CassandraAppStorage`, getting the parent of a node may fail if one of its children is inconsistent. This should not happen since there is no relation at all between this child consistency and the node itself or its parent.

Actually, it does not really make sense to check consistency, even for the parent, here.

**What is the new behavior (if this is a feature change)?**

No check on consistency when getting parent node.

