### PR TITLE
Select distinct for static queries

### DIFF
--- a/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
+++ b/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
@@ -378,7 +378,7 @@ public class CassandraAppStorage extends AbstractAppStorage {
     private String getNodeName(UUID nodeUuid) {
         Objects.requireNonNull(nodeUuid);
         ResultSet resultSet = getSession().execute(select(NAME).from(CHILDREN_BY_NAME_AND_CLASS)
-                                                                         .where(eq(ID, nodeUuid)));
+            .where(eq(ID, nodeUuid)));
         Row row = resultSet.one();
         if (row == null) {
             throw createNodeNotFoundException(nodeUuid);
@@ -720,16 +720,14 @@ public class CassandraAppStorage extends AbstractAppStorage {
     }
 
     private UUID getParentNodeUuid(UUID nodeUuid) {
-        ResultSet resultSet = getSession().execute(select(PARENT_ID, CHILD_CONSISTENT).from(CHILDREN_BY_NAME_AND_CLASS)
+        ResultSet resultSet = getSession().execute(select(PARENT_ID)
+                .from(CHILDREN_BY_NAME_AND_CLASS)
                 .where(eq(ID, nodeUuid)));
         Row row = resultSet.one();
         if (row == null) {
             throw createNodeNotFoundException(nodeUuid);
         }
-        if (isConsistentBackwardCompatible(row, 1)) {
-            return row.getUUID(0);
-        }
-        return null;
+        return row.getUUID(0);
     }
 
     @Override
@@ -1432,7 +1430,7 @@ public class CassandraAppStorage extends AbstractAppStorage {
         UUID nodeUuid = checkNodeId(nodeId);
         Set<NodeInfo> backwardDependencies = new HashSet<>();
         ResultSet resultSet = getSession().execute(select(FROM_ID).from(BACKWARD_DEPENDENCIES)
-                                                                          .where(eq(TO_ID, nodeUuid)));
+                                                                  .where(eq(TO_ID, nodeUuid)));
         for (Row row : resultSet) {
             try {
                 backwardDependencies.add(getNodeInfo(row.getUUID(0)));

--- a/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
+++ b/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
@@ -377,7 +377,7 @@ public class CassandraAppStorage extends AbstractAppStorage {
 
     private String getNodeName(UUID nodeUuid) {
         Objects.requireNonNull(nodeUuid);
-        ResultSet resultSet = getSession().execute(select(NAME).from(CHILDREN_BY_NAME_AND_CLASS)
+        ResultSet resultSet = getSession().execute(select(NAME).distinct().from(CHILDREN_BY_NAME_AND_CLASS)
             .where(eq(ID, nodeUuid)));
         Row row = resultSet.one();
         if (row == null) {
@@ -399,7 +399,7 @@ public class CassandraAppStorage extends AbstractAppStorage {
     public boolean isConsistent(String nodeId) {
         UUID nodeUuid = checkNodeId(nodeId);
         Objects.requireNonNull(nodeUuid);
-        ResultSet resultSet = getSession().execute(select(CONSISTENT)
+        ResultSet resultSet = getSession().execute(select(CONSISTENT).distinct()
                 .from(CHILDREN_BY_NAME_AND_CLASS)
                 .where(eq(ID, nodeUuid)));
         Row row = resultSet.one();
@@ -561,6 +561,7 @@ public class CassandraAppStorage extends AbstractAppStorage {
         Objects.requireNonNull(nodeUuid);
         ResultSet resultSet = getSession().execute(select(NAME, PSEUDO_CLASS, DESCRIPTION, CREATION_DATE,
                                                                   MODIFICATION_DATE, VERSION, MT, MD, MI, MB)
+                .distinct()
                 .from(CHILDREN_BY_NAME_AND_CLASS)
                 .where(eq(ID, nodeUuid)));
         Row row = resultSet.one();
@@ -668,9 +669,10 @@ public class CassandraAppStorage extends AbstractAppStorage {
     @Override
     public List<NodeInfo> getInconsistentNodes() {
         List<NodeInfo> childNodesInfo = new ArrayList<>();
-        ResultSet resultSet = getSession().execute(select(CHILD_NAME, CHILD_PSEUDO_CLASS, CHILD_ID, CHILD_DESCRIPTION,
-                CHILD_CREATION_DATE, CHILD_MODIFICATION_DATE, CHILD_VERSION,
-                CMT, CMD, CMI, CMB, CHILD_CONSISTENT)
+        ResultSet resultSet = getSession().execute(select(NAME, PSEUDO_CLASS, ID, DESCRIPTION,
+                    CREATION_DATE, MODIFICATION_DATE, VERSION,
+                    MT, MD, MI, MB, CONSISTENT)
+                .distinct()
                 .from(CHILDREN_BY_NAME_AND_CLASS));
         for (Row row : resultSet) {
             UUID uuid = row.getUUID(2);
@@ -721,6 +723,7 @@ public class CassandraAppStorage extends AbstractAppStorage {
 
     private UUID getParentNodeUuid(UUID nodeUuid) {
         ResultSet resultSet = getSession().execute(select(PARENT_ID)
+                .distinct()
                 .from(CHILDREN_BY_NAME_AND_CLASS)
                 .where(eq(ID, nodeUuid)));
         Row row = resultSet.one();
@@ -1565,6 +1568,7 @@ public class CassandraAppStorage extends AbstractAppStorage {
 
     private void checkInconsistent(List<FileSystemCheckIssue> results, Instant expirationTime, boolean repair) {
         ResultSet resultSet = getSession().execute(select(ID, NAME, MODIFICATION_DATE, CONSISTENT)
+                .distinct()
                 .from(CHILDREN_BY_NAME_AND_CLASS));
         for (Row row : resultSet) {
             final Optional<FileSystemCheckIssue> issue = buildExpirationInconsistentIssue(row, expirationTime);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Performance/memory usage improvement

**What is the current behavior?** *(You can also link to an open issue here)*

Cassandra queries for static node data (id, parent, ...) get all matching rows, which means 1 row per child of the node. If the node has a lot of children, this can lead to a lot of uselessly duplicated data received from cassandra.

In production system, we observe a surprisingly larger execution time for `getParent` requests than for other requests. We suspect it comes from those unnecessary duplicates.
(**confirmed, see benchmark below**)

**What is the new behavior (if this is a feature change)?**

When querying static node data, we use the `distinct` feature to get only one row.
