### PR TITLE
Fix node deletion events in mapdb and cassandra implementations

### DIFF
--- a/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
+++ b/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
@@ -784,7 +784,6 @@ public class CassandraAppStorage extends AbstractAppStorage {
     public String deleteNode(String nodeId) {
         UUID nodeUuid = checkNodeId(nodeId);
         UUID parentNodeUuid = deleteNode(nodeUuid);
-        pushEvent(new NodeRemoved(nodeId, String.valueOf(parentNodeUuid)), APPSTORAGE_NODE_TOPIC);
         return parentNodeUuid != null ? parentNodeUuid.toString() : null;
     }
 
@@ -846,6 +845,7 @@ public class CassandraAppStorage extends AbstractAppStorage {
             pushEvent(new BackwardDependencyRemoved(value.toString(), key), APPSTORAGE_DEPENDENCY_TOPIC);
         });
 
+        pushEvent(new NodeRemoved(nodeUuid.toString(), String.valueOf(parentNodeUuid)), APPSTORAGE_NODE_TOPIC);
         return parentNodeUuid;
     }
 

--- a/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/MapDbAppStorage.java
+++ b/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/MapDbAppStorage.java
@@ -515,13 +515,11 @@ public class MapDbAppStorage extends AbstractAppStorage {
         }
         NodeInfo nodeInfo = nodeInfoMap.remove(nodeUuid);
         nodeConsistencyMap.remove(nodeUuid);
-        for (String dataName : dataNamesMap.get(nodeUuid)) {
-            boolean removed = dataMap.remove(new NamedLink(nodeUuid, dataName)) != null;
-            if (removed) {
-                pushEvent(new NodeDataRemoved(nodeUuid.toString(), dataName), APPSTORAGE_NODE_TOPIC);
-            }
-        }
-        dataNamesMap.remove(nodeUuid);
+        Set<String> removedData = dataNamesMap.remove(nodeUuid);
+        removedData.forEach(dataName -> {
+            dataMap.remove(new NamedLink(nodeUuid, dataName));
+            pushEvent(new NodeDataRemoved(nodeUuid.toString(), dataName), APPSTORAGE_NODE_TOPIC);
+        });
         childNodesMap.remove(nodeUuid);
         UUID parentNodeUuid = parentNodeMap.remove(nodeUuid);
         removeFromList(childNodesMap, parentNodeUuid, nodeUuid);

--- a/afs-storage-api/src/test/java/com/powsybl/afs/storage/AbstractAppStorageTest.java
+++ b/afs-storage-api/src/test/java/com/powsybl/afs/storage/AbstractAppStorageTest.java
@@ -29,8 +29,10 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.*;
 
 /**
@@ -65,6 +67,22 @@ public abstract class AbstractAppStorageTest {
         for (NodeEvent event : events) {
             assertEquals(event, eventStack.take());
         }
+
+        // assert all events have been checked
+        assertTrue(eventStack.isEmpty());
+    }
+
+    private void assertEventStackInAnyOrder(NodeEvent... expectedEvents) throws InterruptedException {
+        List<NodeEvent> collectedEvents = new ArrayList<>();
+        for (int i = 0; i < expectedEvents.length; i++) {
+            NodeEvent event = eventStack.poll(1, TimeUnit.SECONDS);
+            if (event == null) {
+                break;
+            }
+            collectedEvents.add(event);
+        }
+        assertThat(collectedEvents)
+            .containsExactlyInAnyOrder(expectedEvents);
 
         // assert all events have been checked
         assertTrue(eventStack.isEmpty());
@@ -576,6 +594,8 @@ public abstract class AbstractAppStorageTest {
         assertThat(eventsCatched.get().getEvents().get(0)).isEqualTo(eventToCatch);
         assertEventStack(eventNotToCatch, eventToCatch);
 
+        testCascadingDelete(rootFolderInfo);
+
         nextDependentTests();
     }
 
@@ -671,5 +691,47 @@ public abstract class AbstractAppStorageTest {
         clone.getInts().putAll(metadata.getInts());
         clone.getDoubles().putAll(metadata.getDoubles());
         return clone;
+    }
+
+    private void testCascadingDelete(NodeInfo rootFolderInfo) throws IOException, InterruptedException {
+        NodeInfo subFolder = storage.createNode(rootFolderInfo.getId(), "test-delete", FOLDER_PSEUDO_CLASS, "", 0, new NodeGenericMetadata());
+        storage.setConsistent(subFolder.getId());
+        NodeInfo subSubFolder = storage.createNode(subFolder.getId(), "sub-folder", FOLDER_PSEUDO_CLASS, "", 0, new NodeGenericMetadata());
+        storage.setConsistent(subSubFolder.getId());
+        NodeInfo data1 = storage.createNode(subFolder.getId(), "data1", DATA_FILE_CLASS, "", 0, new NodeGenericMetadata());
+        storage.setConsistent(data1.getId());
+        NodeInfo data2 = storage.createNode(subSubFolder.getId(), "data1", DATA_FILE_CLASS, "", 0, new NodeGenericMetadata());
+        storage.setConsistent(data2.getId());
+
+        try (OutputStream outputStream = storage.writeBinaryData(data1.getId(), "data1")) {
+            outputStream.write("data1".getBytes(StandardCharsets.UTF_8));
+        }
+        try (OutputStream outputStream = storage.writeBinaryData(data2.getId(), "data2")) {
+            outputStream.write("data2".getBytes(StandardCharsets.UTF_8));
+        }
+
+        storage.deleteNode(subFolder.getId());
+        storage.flush();
+
+        //Dicard events up until deletion
+        discardEvents(10);
+
+        assertThatExceptionOfType(RuntimeException.class)
+            .isThrownBy(() -> storage.getNodeInfo(subFolder.getId()));
+        assertThatExceptionOfType(RuntimeException.class)
+            .isThrownBy(() -> storage.getNodeInfo(subSubFolder.getId()));
+        assertThatExceptionOfType(RuntimeException.class)
+            .isThrownBy(() -> storage.getNodeInfo(data1.getId()));
+        assertThatExceptionOfType(RuntimeException.class)
+            .isThrownBy(() -> storage.getNodeInfo(data2.getId()));
+
+        assertEventStackInAnyOrder(
+            new NodeRemoved(subFolder.getId(), rootFolderInfo.getId()),
+            new NodeRemoved(subSubFolder.getId(), subFolder.getId()),
+            new NodeRemoved(data1.getId(), subFolder.getId()),
+            new NodeRemoved(data2.getId(), subSubFolder.getId()),
+            new NodeDataRemoved(data1.getId(), "data1"),
+            new NodeDataRemoved(data2.getId(), "data2")
+        );
     }
 }

--- a/afs-storage-api/src/test/java/com/powsybl/afs/storage/AbstractAppStorageTest.java
+++ b/afs-storage-api/src/test/java/com/powsybl/afs/storage/AbstractAppStorageTest.java
@@ -29,7 +29,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;


### PR DESCRIPTION

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Bug fix.

**What is the current behavior?** *(You can also link to an open issue here)*

When calling `node.delete()`, some events are not raised:
 * children nodes removal events
 * data removal events

**What is the new behavior (if this is a feature change)?**

All events corresponding to the elements actually deleted are raised.

