### PR TITLE
Ajout du node ID dans le start Task

### DIFF
--- a/afs-core/src/main/java/com/powsybl/afs/LocalTaskMonitor.java
+++ b/afs-core/src/main/java/com/powsybl/afs/LocalTaskMonitor.java
@@ -53,7 +53,7 @@ public class LocalTaskMonitor implements TaskMonitor {
             tasks.put(task.getId(), task);
 
             // notification
-            notifyListeners(new StartTaskEvent(task.getId(), revision, name), task.getProjectId());
+            notifyListeners(new StartTaskEvent(task.getId(), revision, name, nodeId), task.getProjectId());
 
             return task;
         } finally {

--- a/afs-core/src/main/java/com/powsybl/afs/StartTaskEvent.java
+++ b/afs-core/src/main/java/com/powsybl/afs/StartTaskEvent.java
@@ -20,19 +20,34 @@ public class StartTaskEvent extends TaskEvent {
     @JsonProperty("name")
     private final String name;
 
+    @JsonProperty("nodeId")
+    private final String nodeId;
+
     @JsonCreator
-    public StartTaskEvent(@JsonProperty("taskId") UUID taskId, @JsonProperty("revision") long revision, @JsonProperty("name") String name) {
+    public StartTaskEvent(@JsonProperty("taskId") UUID taskId,
+                          @JsonProperty("revision") long revision,
+                          @JsonProperty("name") String name,
+                          @JsonProperty("nodeId") String nodeId) {
         super(taskId, revision);
         this.name = Objects.requireNonNull(name);
+        this.nodeId = nodeId;
+    }
+
+    public StartTaskEvent(@JsonProperty("taskId") UUID taskId, @JsonProperty("revision") long revision, @JsonProperty("name") String name) {
+        this(taskId, revision, name, null);
     }
 
     public String getName() {
         return name;
     }
 
+    public String getNodeId() {
+        return nodeId;
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hash(taskId, revision, name);
+        return Objects.hash(taskId, revision, name, nodeId);
     }
 
     @Override
@@ -41,13 +56,14 @@ public class StartTaskEvent extends TaskEvent {
             StartTaskEvent other = (StartTaskEvent) obj;
             return taskId.equals(other.taskId) &&
                     revision == other.revision &&
-                    name.equals(other.name);
+                    name.equals(other.name) &&
+                    nodeId.equals(other.nodeId);
         }
         return false;
     }
 
     @Override
     public String toString() {
-        return "StartTaskEvent(taskId=" + taskId + ", revision=" + revision + ", name=" + name + ")";
+        return "StartTaskEvent(taskId=" + taskId + ", revision=" + revision + ", nodeId=" + nodeId + ", name=" + name + ")";
     }
 }


### PR DESCRIPTION
Signed-off-by: quentin <quentin.capy@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
issue from Imagrid team who need the node id of a task to link the task notification to the afs node 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
A new field is available on StartTaskEvent to get the nodeId link to this task 


**What is the current behavior?** *(You can also link to an open issue here)*
no link possible between task and afs node with task notification


**What is the new behavior (if this is a feature change)?**
the provided nodeID link the task and afs node during startTask notification


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
there is no breaking change on the backend part. All listener should check if they check explicitly all tag of this event "StartTaskEvent" in order to add the possibility to find the nodeId
(if any of the questions/checkboxes don't apply, please delete them entirely)
