### PR TITLE
Workaround javadoc generation issue with JDK 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,10 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <!-- Workaround javadoc generation issue with JDK 11, on java EE classes (bug in JDK?)-->
+                            <release>8</release>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>javadoc-aggregate-jar</id>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Bugfix

**What is the current behavior?** *(You can also link to an open issue here)*

Our code references java 8 classes from javaEE 7.0,
which does not seem to work well while generating javadoc.

**What is the new behavior (if this is a feature change)?**

We use the "release=8" option to ensure source compatibility.

