### PR TITLE
fix metadata while rename

### DIFF
--- a/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
+++ b/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
@@ -599,7 +599,7 @@ public class CassandraAppStorage extends AbstractAppStorage {
                     .value(CHILD_CREATION_DATE, literal(Instant.ofEpochMilli(nodeInfo.getCreationTime())))
                     .value(CHILD_MODIFICATION_DATE, literal(Instant.ofEpochMilli(nodeInfo.getModificationTime())))
                     .value(CHILD_VERSION, literal(nodeInfo.getVersion()))
-                    .values(addAllMetadata(nodeInfo))
+                    .values(addAllChildMetadata(nodeInfo))
                     .build());
 
             getSession().execute(update(CHILDREN_BY_NAME_AND_CLASS)


### PR DESCRIPTION
Signed-off-by: Quentin <quentin.capy@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Fix lost of metadata while renaming child.


**What is the current behavior?** *(You can also link to an open issue here)*
while calling rename, the metadata are lost 


**What is the new behavior (if this is a feature change)?**
keep metadata 