### PR TITLE
Cassandra fix node version

### DIFF
--- a/afs-action-dsl/pom.xml
+++ b/afs-action-dsl/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-afs</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/afs-cassandra/pom.xml
+++ b/afs-cassandra/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-afs</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-afs-cassandra</artifactId>

--- a/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
+++ b/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
@@ -472,6 +472,7 @@ public class CassandraAppStorage extends AbstractAppStorage {
                 .value(CONSISTENT, literal(false))
                 .value(CREATION_DATE, literal(Instant.ofEpochMilli(creationTime)))
                 .value(MODIFICATION_DATE, literal(Instant.ofEpochMilli(creationTime)))
+                .value(VERSION, literal(version))
                 .values(addAllMetadata(genericMetadata))
                 .build());
 

--- a/afs-contingency/pom.xml
+++ b/afs-contingency/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-afs</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-afs-contingency</artifactId>

--- a/afs-core/pom.xml
+++ b/afs-core/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>powsybl-afs</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-afs-core</artifactId>

--- a/afs-distribution/pom.xml
+++ b/afs-distribution/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>powsybl-afs</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/afs-ext-base/pom.xml
+++ b/afs-ext-base/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>powsybl-afs</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-afs-ext-base</artifactId>

--- a/afs-local/pom.xml
+++ b/afs-local/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>powsybl-afs</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-afs-local</artifactId>

--- a/afs-mapdb-storage/pom.xml
+++ b/afs-mapdb-storage/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>powsybl-afs</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-afs-mapdb-storage</artifactId>

--- a/afs-mapdb/pom.xml
+++ b/afs-mapdb/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>powsybl-afs</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-afs-mapdb</artifactId>

--- a/afs-network/afs-network-client/pom.xml
+++ b/afs-network/afs-network-client/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-afs-network</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-afs-network-client</artifactId>

--- a/afs-network/afs-network-server/pom.xml
+++ b/afs-network/afs-network-server/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-afs-network</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-afs-network-server</artifactId>

--- a/afs-network/pom.xml
+++ b/afs-network/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-afs</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-afs-network</artifactId>

--- a/afs-scripting/pom.xml
+++ b/afs-scripting/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>powsybl-afs</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/afs-security-analysis-local/pom.xml
+++ b/afs-security-analysis-local/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-afs</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-afs-security-analysis-local</artifactId>

--- a/afs-security-analysis/pom.xml
+++ b/afs-security-analysis/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-afs</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-afs-security-analysis</artifactId>

--- a/afs-spring-server/pom.xml
+++ b/afs-spring-server/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-afs</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-afs-spring-server</artifactId>

--- a/afs-storage-api/pom.xml
+++ b/afs-storage-api/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>powsybl-afs</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-afs-storage-api</artifactId>

--- a/afs-storage-api/src/test/java/com/powsybl/afs/storage/AbstractAppStorageTest.java
+++ b/afs-storage-api/src/test/java/com/powsybl/afs/storage/AbstractAppStorageTest.java
@@ -123,7 +123,7 @@ public abstract class AbstractAppStorageTest {
         assertTrue(storage.getChildNodes(rootFolderInfo.getId()).isEmpty());
 
         // 2) create a test folder
-        NodeInfo testFolderInfo = storage.createNode(rootFolderInfo.getId(), "test", FOLDER_PSEUDO_CLASS, "", 0,
+        NodeInfo testFolderInfo = storage.createNode(rootFolderInfo.getId(), "test", FOLDER_PSEUDO_CLASS, "", 12,
                 new NodeGenericMetadata().setString("k", "v"));
         storage.flush();
 
@@ -144,17 +144,18 @@ public abstract class AbstractAppStorageTest {
         assertEquals(rootFolderInfo, storage.getParentNode(testFolderInfo.getId()).orElseThrow(AssertionError::new));
 
         // check test folder infos are corrects
-        assertEquals(testFolderInfo.getId(), storage.getNodeInfo(testFolderInfo.getId()).getId());
-        assertEquals("test", storage.getNodeInfo(testFolderInfo.getId()).getName());
-        assertEquals(FOLDER_PSEUDO_CLASS, storage.getNodeInfo(testFolderInfo.getId()).getPseudoClass());
-        assertEquals(0, storage.getNodeInfo(testFolderInfo.getId()).getVersion());
-        assertEquals(Collections.singletonMap("k", "v"), storage.getNodeInfo(testFolderInfo.getId()).getGenericMetadata().getStrings());
-        assertTrue(storage.getNodeInfo(testFolderInfo.getId()).getGenericMetadata().getDoubles().isEmpty());
-        assertTrue(storage.getNodeInfo(testFolderInfo.getId()).getGenericMetadata().getInts().isEmpty());
-        assertTrue(storage.getNodeInfo(testFolderInfo.getId()).getGenericMetadata().getBooleans().isEmpty());
-        assertEquals("", storage.getNodeInfo(testFolderInfo.getId()).getDescription());
-        assertTrue(storage.getNodeInfo(testFolderInfo.getId()).getCreationTime() > 0);
-        assertTrue(storage.getNodeInfo(testFolderInfo.getId()).getModificationTime() > 0);
+        NodeInfo retrievedTestFolderInfo = storage.getNodeInfo(testFolderInfo.getId());
+        assertEquals(testFolderInfo.getId(), retrievedTestFolderInfo.getId());
+        assertEquals("test", retrievedTestFolderInfo.getName());
+        assertEquals(FOLDER_PSEUDO_CLASS, retrievedTestFolderInfo.getPseudoClass());
+        assertEquals(12, retrievedTestFolderInfo.getVersion());
+        assertEquals(Collections.singletonMap("k", "v"), retrievedTestFolderInfo.getGenericMetadata().getStrings());
+        assertTrue(retrievedTestFolderInfo.getGenericMetadata().getDoubles().isEmpty());
+        assertTrue(retrievedTestFolderInfo.getGenericMetadata().getInts().isEmpty());
+        assertTrue(retrievedTestFolderInfo.getGenericMetadata().getBooleans().isEmpty());
+        assertEquals("", retrievedTestFolderInfo.getDescription());
+        assertTrue(retrievedTestFolderInfo.getCreationTime() > 0);
+        assertTrue(retrievedTestFolderInfo.getModificationTime() > 0);
 
         // check test folder is empty
         assertTrue(storage.getChildNodes(testFolderInfo.getId()).isEmpty());

--- a/afs-ws/afs-ws-client-utils/pom.xml
+++ b/afs-ws/afs-ws-client-utils/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-afs-ws</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-afs-ws-client-utils</artifactId>

--- a/afs-ws/afs-ws-client/pom.xml
+++ b/afs-ws/afs-ws-client/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-afs-ws</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-afs-ws-client</artifactId>

--- a/afs-ws/afs-ws-server-utils/pom.xml
+++ b/afs-ws/afs-ws-server-utils/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-afs-ws</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-afs-ws-server-utils</artifactId>

--- a/afs-ws/afs-ws-server/pom.xml
+++ b/afs-ws/afs-ws-server/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-afs-ws</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-afs-ws-server</artifactId>

--- a/afs-ws/afs-ws-storage/pom.xml
+++ b/afs-ws/afs-ws-storage/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-afs-ws</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-afs-ws-storage</artifactId>

--- a/afs-ws/afs-ws-utils/pom.xml
+++ b/afs-ws/afs-ws-utils/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-afs-ws</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-afs-ws-utils</artifactId>

--- a/afs-ws/pom.xml
+++ b/afs-ws/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-afs</artifactId>
-        <version>5.0.1</version>
+        <version>5.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-afs-ws</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <relativePath/>
     </parent>
     <artifactId>powsybl-afs</artifactId>
-    <version>5.0.1</version>
+    <version>5.0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>powsybl-afs</name>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Bugfix

**What is the current behavior?** *(You can also link to an open issue here)*

The cassandra implementation of AFS does not store correctly the node version, but 0 instead.
This was not covered by unit tests.

**What is the new behavior (if this is a feature change)?**

Version is correctly stored and retrieved.
