### PR TITLE
Fix storage node rename to not delete children nodes with same names

### DIFF
--- a/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
+++ b/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
@@ -589,6 +589,7 @@ public class CassandraAppStorage extends AbstractAppStorage {
             getSession().execute(deleteFrom(CHILDREN_BY_NAME_AND_CLASS)
                     .whereColumn(ID).isEqualTo(literal(parentNodeUuid))
                     .whereColumn(CHILD_NAME).isEqualTo(literal(nodeInfo.getName()))
+                    .whereColumn(CHILD_PSEUDO_CLASS).isEqualTo(literal(nodeInfo.getPseudoClass()))
                     .build());
 
             getSession().execute(insertInto(CHILDREN_BY_NAME_AND_CLASS)

--- a/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraAppStorageTest.java
+++ b/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraAppStorageTest.java
@@ -101,6 +101,9 @@ public class CassandraAppStorageTest extends AbstractAppStorageTest {
         new CassandraRenameIssueTest().test(storage);
         clear();
 
+        new CassandraRenameIssueTest().testRenameChildWithSameName(storage);
+        clear();
+
         new TimeSeriesIssueTest().testEmptyChunks(storage);
         clear();
         new TimeSeriesIssueTest().testNullString(storage);

--- a/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraRenameIssueTest.java
+++ b/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraRenameIssueTest.java
@@ -10,7 +10,11 @@ import com.powsybl.afs.storage.AppStorage;
 import com.powsybl.afs.storage.NodeGenericMetadata;
 import com.powsybl.afs.storage.NodeInfo;
 
+import java.util.List;
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -31,5 +35,28 @@ public class CassandraRenameIssueTest {
         storage.flush();
         assertEquals(2, storage.getChildNodes(test1NodeInfo.getId()).size());
         assertEquals("newtest1", storage.getNodeInfo(test1NodeInfo.getId()).getName());
+    }
+
+    public void testRenameChildWithSameName(AppStorage storage) {
+        NodeInfo rootNodeId = storage.createRootNodeIfNotExists("test", "folder");
+        NodeInfo test1NodeInfo = storage.createNode(rootNodeId.getId(), "test1", "folder", "", 0, new NodeGenericMetadata());
+        storage.flush();
+        NodeInfo test2Project = storage.createNode(test1NodeInfo.getId(), "test2", "project", "", 0, new NodeGenericMetadata());
+        storage.setConsistent(test2Project.getId());
+        NodeInfo test2Folder = storage.createNode(test1NodeInfo.getId(), "test2", "folder", "", 0, new NodeGenericMetadata());
+        storage.setConsistent(test2Folder.getId());
+        storage.flush();
+        storage.renameNode(test2Project.getId(), "newTest2");
+        storage.flush();
+        List<NodeInfo> childNodes = storage.getChildNodes(test1NodeInfo.getId());
+        assertEquals(2, childNodes.size());
+        Optional<NodeInfo> first = childNodes.stream().filter(nodeInfo -> nodeInfo.getId().equals(test2Project.getId())).findFirst();
+        assertTrue(first.isPresent());
+        assertEquals("newTest2", first.get().getName());
+        Optional<NodeInfo> second = childNodes.stream().filter(nodeInfo -> nodeInfo.getId().equals(test2Folder.getId())).findFirst();
+        assertTrue(second.isPresent());
+        assertEquals("test2", second.get().getName());
+        assertEquals("test2", storage.getNodeInfo(test2Folder.getId()).getName());
+        assertEquals("newTest2", storage.getNodeInfo(test2Project.getId()).getName());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Fix rename, add al primary key while deleting old node.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
While renaming a node, all node with the same in the folder name where deleted



**What is the new behavior (if this is a feature change)?**
only the old renamed node is deleted
