### PR TITLE
Add literal annotation in author's email address

### DIFF
--- a/afs-action-dsl/src/main/java/com/powsybl/afs/action/dsl/ActionScript.java
+++ b/afs-action-dsl/src/main/java/com/powsybl/afs/action/dsl/ActionScript.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 import java.util.ResourceBundle;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ActionScript extends AbstractScript<ActionScript> implements ContingenciesProvider {
 

--- a/afs-action-dsl/src/main/java/com/powsybl/afs/action/dsl/ActionScriptBuilder.java
+++ b/afs-action-dsl/src/main/java/com/powsybl/afs/action/dsl/ActionScriptBuilder.java
@@ -19,7 +19,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ActionScriptBuilder implements ProjectFileBuilder<ActionScript> {
 

--- a/afs-action-dsl/src/main/java/com/powsybl/afs/action/dsl/ActionScriptExtension.java
+++ b/afs-action-dsl/src/main/java/com/powsybl/afs/action/dsl/ActionScriptExtension.java
@@ -12,7 +12,7 @@ import com.powsybl.afs.ProjectFileCreationContext;
 import com.powsybl.afs.ProjectFileExtension;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(ProjectFileExtension.class)
 public class ActionScriptExtension implements ProjectFileExtension<ActionScript, ActionScriptBuilder> {

--- a/afs-action-dsl/src/test/java/com/powsybl/afs/action/dsl/ActionScriptTest.java
+++ b/afs-action-dsl/src/test/java/com/powsybl/afs/action/dsl/ActionScriptTest.java
@@ -25,7 +25,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ActionScriptTest extends AbstractProjectFileTest {
 

--- a/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAfsException.java
+++ b/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAfsException.java
@@ -7,7 +7,7 @@
 package com.powsybl.afs.cassandra;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class CassandraAfsException extends RuntimeException {
 

--- a/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppFileSystem.java
+++ b/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppFileSystem.java
@@ -10,7 +10,7 @@ import com.powsybl.afs.AppFileSystem;
 import com.powsybl.afs.storage.AppStorage;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class CassandraAppFileSystem extends AppFileSystem {
 

--- a/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppFileSystemConfig.java
+++ b/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppFileSystemConfig.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class CassandraAppFileSystemConfig extends AbstractAppFileSystemConfig<CassandraAppFileSystemConfig> {
 

--- a/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppFileSystemProvider.java
+++ b/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppFileSystemProvider.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(AppFileSystemProvider.class)
 public class CassandraAppFileSystemProvider implements AppFileSystemProvider {

--- a/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
+++ b/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorage.java
@@ -42,7 +42,7 @@ import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.*;
 import static com.powsybl.afs.cassandra.CassandraConstants.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class CassandraAppStorage extends AbstractAppStorage {
 

--- a/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorageConfig.java
+++ b/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraAppStorageConfig.java
@@ -10,7 +10,7 @@ import com.powsybl.commons.config.ModuleConfig;
 import com.powsybl.commons.config.PlatformConfig;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class CassandraAppStorageConfig {
 

--- a/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraConstants.java
+++ b/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraConstants.java
@@ -7,7 +7,7 @@
 package com.powsybl.afs.cassandra;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class CassandraConstants {
 

--- a/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraContext.java
+++ b/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraContext.java
@@ -9,7 +9,7 @@ package com.powsybl.afs.cassandra;
 import com.datastax.oss.driver.api.core.CqlSession;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface CassandraContext extends AutoCloseable {
 

--- a/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraSimpleContext.java
+++ b/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraSimpleContext.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class CassandraSimpleContext implements CassandraContext {
 

--- a/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraUtil.java
+++ b/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/CassandraUtil.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.selectFrom;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class CassandraUtil {
 

--- a/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/NodeMetadataGetter.java
+++ b/afs-cassandra/src/main/java/com/powsybl/afs/cassandra/NodeMetadataGetter.java
@@ -14,7 +14,7 @@ import java.util.function.Function;
 /**
  * Helps exporting metadata to cassandra
  *
- * @author Quentin CAPY <cappy.quentin at rte-france.com>
+ * @author Quentin CAPY {@literal <cappy.quentin at rte-france.com>}
  */
 enum NodeMetadataGetter {
     DOUBLE("md", NodeGenericMetadata::getDoubles),

--- a/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraAppStorageTest.java
+++ b/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraAppStorageTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.fail;
 import static org.junit.Assert.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class CassandraAppStorageTest extends AbstractAppStorageTest {
 

--- a/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraDataSplitTest.java
+++ b/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraDataSplitTest.java
@@ -26,7 +26,7 @@ import static com.powsybl.afs.cassandra.CassandraConstants.*;
 import static org.junit.Assert.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class CassandraDataSplitTest {
 

--- a/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraDescriptionIssueTest.java
+++ b/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraDescriptionIssueTest.java
@@ -13,7 +13,7 @@ import com.powsybl.afs.storage.NodeInfo;
 import static org.junit.Assert.assertEquals;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class CassandraDescriptionIssueTest {
 

--- a/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraLeakTest.java
+++ b/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraLeakTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class CassandraLeakTest {
 

--- a/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraRemoveCreateFolderIssueTest.java
+++ b/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraRemoveCreateFolderIssueTest.java
@@ -14,7 +14,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class CassandraRemoveCreateFolderIssueTest {
 

--- a/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraRenameIssueTest.java
+++ b/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraRenameIssueTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class CassandraRenameIssueTest {
 

--- a/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraTestContext.java
+++ b/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/CassandraTestContext.java
@@ -10,7 +10,7 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import org.cassandraunit.CassandraCQLUnit;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class CassandraTestContext implements CassandraContext {
 

--- a/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/TimeSeriesIssueTest.java
+++ b/afs-cassandra/src/test/java/com/powsybl/afs/cassandra/TimeSeriesIssueTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class TimeSeriesIssueTest {
 

--- a/afs-contingency/src/main/java/com/powsybl/afs/contingency/ContingencyStore.java
+++ b/afs-contingency/src/main/java/com/powsybl/afs/contingency/ContingencyStore.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ContingencyStore extends ProjectFile implements ContingenciesProvider {
 

--- a/afs-contingency/src/main/java/com/powsybl/afs/contingency/ContingencyStoreBuilder.java
+++ b/afs-contingency/src/main/java/com/powsybl/afs/contingency/ContingencyStoreBuilder.java
@@ -16,7 +16,7 @@ import com.powsybl.afs.storage.NodeInfo;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ContingencyStoreBuilder implements ProjectFileBuilder<ContingencyStore> {
 

--- a/afs-contingency/src/main/java/com/powsybl/afs/contingency/ContingencyStoreExtension.java
+++ b/afs-contingency/src/main/java/com/powsybl/afs/contingency/ContingencyStoreExtension.java
@@ -12,7 +12,7 @@ import com.powsybl.afs.ProjectFileCreationContext;
 import com.powsybl.afs.ProjectFileExtension;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(ProjectFileExtension.class)
 public class ContingencyStoreExtension implements ProjectFileExtension<ContingencyStore, ContingencyStoreBuilder> {

--- a/afs-contingency/src/test/java/com/powsybl/afs/contingency/ContingencyStoreTest.java
+++ b/afs-contingency/src/test/java/com/powsybl/afs/contingency/ContingencyStoreTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ContingencyStoreTest extends AbstractProjectFileTest {
 

--- a/afs-core/src/main/java-templates/com/powsybl/afs/PowsyblAfsVersion.java
+++ b/afs-core/src/main/java-templates/com/powsybl/afs/PowsyblAfsVersion.java
@@ -12,7 +12,7 @@ import com.powsybl.tools.AbstractVersion;
 import com.powsybl.tools.Version;
 
 /**
- * @author Paul Bui-Quang <paul.buiquang at rte-france.com>
+ * @author Paul Bui-Quang {@literal <paul.buiquang at rte-france.com>}
  */
 @AutoService(Version.class)
 public class PowsyblAfsVersion extends AbstractVersion {

--- a/afs-core/src/main/java/com/powsybl/afs/AbstractNodeBase.java
+++ b/afs-core/src/main/java/com/powsybl/afs/AbstractNodeBase.java
@@ -26,7 +26,7 @@ import java.util.stream.Stream;
 /**
  * Base class for all node objects stored in an AFS tree.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractNodeBase<F> {
 

--- a/afs-core/src/main/java/com/powsybl/afs/AfsCircularDependencyException.java
+++ b/afs-core/src/main/java/com/powsybl/afs/AfsCircularDependencyException.java
@@ -11,7 +11,7 @@ package com.powsybl.afs;
 import com.powsybl.commons.PowsyblException;
 
 /**
- * @author Paul Bui-Quang <paul.buiquang at rte-france.com>
+ * @author Paul Bui-Quang {@literal <paul.buiquang at rte-france.com>}
  */
 public class AfsCircularDependencyException extends PowsyblException {
 

--- a/afs-core/src/main/java/com/powsybl/afs/AfsException.java
+++ b/afs-core/src/main/java/com/powsybl/afs/AfsException.java
@@ -9,7 +9,7 @@ package com.powsybl.afs;
 import com.powsybl.commons.PowsyblException;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AfsException extends PowsyblException {
 

--- a/afs-core/src/main/java/com/powsybl/afs/AppData.java
+++ b/afs-core/src/main/java/com/powsybl/afs/AppData.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
  *
  * </pre>
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AppData implements AutoCloseable {
 

--- a/afs-core/src/main/java/com/powsybl/afs/AppFileSystem.java
+++ b/afs-core/src/main/java/com/powsybl/afs/AppFileSystem.java
@@ -35,7 +35,7 @@ import java.util.Optional;
  * <p>
  * Users of an AppFileSystem should not need to interact directly with the underlying {@link AppStorage}.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AppFileSystem implements AutoCloseable {
 

--- a/afs-core/src/main/java/com/powsybl/afs/AppFileSystemProvider.java
+++ b/afs-core/src/main/java/com/powsybl/afs/AppFileSystemProvider.java
@@ -11,7 +11,7 @@ import java.util.List;
 /**
  *
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface AppFileSystemProvider {
 

--- a/afs-core/src/main/java/com/powsybl/afs/AppFileSystemProviderContext.java
+++ b/afs-core/src/main/java/com/powsybl/afs/AppFileSystemProviderContext.java
@@ -12,7 +12,7 @@ import com.powsybl.computation.ComputationManager;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AppFileSystemProviderContext {
 

--- a/afs-core/src/main/java/com/powsybl/afs/AppFileSystemTool.java
+++ b/afs-core/src/main/java/com/powsybl/afs/AppFileSystemTool.java
@@ -24,7 +24,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(Tool.class)
 public class AppFileSystemTool implements Tool {

--- a/afs-core/src/main/java/com/powsybl/afs/AppLogger.java
+++ b/afs-core/src/main/java/com/powsybl/afs/AppLogger.java
@@ -7,7 +7,7 @@
 package com.powsybl.afs;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface AppLogger {
 

--- a/afs-core/src/main/java/com/powsybl/afs/DefaultProjectFileListener.java
+++ b/afs-core/src/main/java/com/powsybl/afs/DefaultProjectFileListener.java
@@ -7,7 +7,7 @@
 package com.powsybl.afs;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class DefaultProjectFileListener implements ProjectFileListener {
 

--- a/afs-core/src/main/java/com/powsybl/afs/DependencyCache.java
+++ b/afs-core/src/main/java/com/powsybl/afs/DependencyCache.java
@@ -18,7 +18,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * <p>
  * The objects are cached when retrieved, and will not be fetched again until invalidation of the cache.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class DependencyCache<T extends ProjectNode> {
 

--- a/afs-core/src/main/java/com/powsybl/afs/File.java
+++ b/afs-core/src/main/java/com/powsybl/afs/File.java
@@ -11,7 +11,7 @@ package com.powsybl.afs;
  * A file in an {@link AppFileSystem} object. New types of files may be added through
  * the extension mechanism (see {@link FileExtension}).
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class File extends Node {
 

--- a/afs-core/src/main/java/com/powsybl/afs/FileCreationContext.java
+++ b/afs-core/src/main/java/com/powsybl/afs/FileCreationContext.java
@@ -12,7 +12,7 @@ import com.powsybl.afs.storage.NodeInfo;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class FileCreationContext {
 

--- a/afs-core/src/main/java/com/powsybl/afs/FileExtension.java
+++ b/afs-core/src/main/java/com/powsybl/afs/FileExtension.java
@@ -34,7 +34,7 @@ package com.powsybl.afs;
  * }
  * </pre>
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface FileExtension<T extends File> {
 

--- a/afs-core/src/main/java/com/powsybl/afs/Folder.java
+++ b/afs-core/src/main/java/com/powsybl/afs/Folder.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
  * <p>
  * Folders may have children folders or files, and provides methods to create new children.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class Folder extends Node implements FolderBase<Node, Folder> {
 

--- a/afs-core/src/main/java/com/powsybl/afs/FolderBase.java
+++ b/afs-core/src/main/java/com/powsybl/afs/FolderBase.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface FolderBase<N extends AbstractNodeBase<F>, F extends FolderBase<N, F>> {
 

--- a/afs-core/src/main/java/com/powsybl/afs/LocalTaskMonitor.java
+++ b/afs-core/src/main/java/com/powsybl/afs/LocalTaskMonitor.java
@@ -16,7 +16,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LocalTaskMonitor implements TaskMonitor {
 

--- a/afs-core/src/main/java/com/powsybl/afs/Node.java
+++ b/afs-core/src/main/java/com/powsybl/afs/Node.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class Node extends AbstractNodeBase<Folder> {
 

--- a/afs-core/src/main/java/com/powsybl/afs/NodePath.java
+++ b/afs-core/src/main/java/com/powsybl/afs/NodePath.java
@@ -13,7 +13,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodePath {
 

--- a/afs-core/src/main/java/com/powsybl/afs/OrderedDependencyManager.java
+++ b/afs-core/src/main/java/com/powsybl/afs/OrderedDependencyManager.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * @author Paul Bui-Quang <paul.buiquang at rte-france.com>
+ * @author Paul Bui-Quang {@literal <paul.buiquang at rte-france.com>}
  */
 public class OrderedDependencyManager {
 

--- a/afs-core/src/main/java/com/powsybl/afs/Project.java
+++ b/afs-core/src/main/java/com/powsybl/afs/Project.java
@@ -16,7 +16,7 @@ import java.util.Objects;
  * <p>
  * A project will have its own tree of project folders and project files, with possible dependencies between files.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class Project extends File {
 

--- a/afs-core/src/main/java/com/powsybl/afs/ProjectDependency.java
+++ b/afs-core/src/main/java/com/powsybl/afs/ProjectDependency.java
@@ -9,7 +9,7 @@ package com.powsybl.afs;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ProjectDependency<T extends ProjectNode> {
 

--- a/afs-core/src/main/java/com/powsybl/afs/ProjectFile.java
+++ b/afs-core/src/main/java/com/powsybl/afs/ProjectFile.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ProjectFile extends ProjectNode {
 

--- a/afs-core/src/main/java/com/powsybl/afs/ProjectFileBuildContext.java
+++ b/afs-core/src/main/java/com/powsybl/afs/ProjectFileBuildContext.java
@@ -12,7 +12,7 @@ import com.powsybl.afs.storage.NodeInfo;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ProjectFileBuildContext extends ProjectFileContext {
 

--- a/afs-core/src/main/java/com/powsybl/afs/ProjectFileBuilder.java
+++ b/afs-core/src/main/java/com/powsybl/afs/ProjectFileBuilder.java
@@ -7,7 +7,7 @@
 package com.powsybl.afs;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface ProjectFileBuilder<F extends ProjectFile> {
 

--- a/afs-core/src/main/java/com/powsybl/afs/ProjectFileContext.java
+++ b/afs-core/src/main/java/com/powsybl/afs/ProjectFileContext.java
@@ -11,7 +11,7 @@ import com.powsybl.afs.storage.AppStorage;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ProjectFileContext {
 

--- a/afs-core/src/main/java/com/powsybl/afs/ProjectFileCreationContext.java
+++ b/afs-core/src/main/java/com/powsybl/afs/ProjectFileCreationContext.java
@@ -12,7 +12,7 @@ import com.powsybl.afs.storage.NodeInfo;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ProjectFileCreationContext extends ProjectFileContext {
 

--- a/afs-core/src/main/java/com/powsybl/afs/ProjectFileExtension.java
+++ b/afs-core/src/main/java/com/powsybl/afs/ProjectFileExtension.java
@@ -52,7 +52,7 @@ import java.util.List;
  *  }
  * </pre>
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface ProjectFileExtension<T extends ProjectFile, U extends ProjectFileBuilder<T>> {
 

--- a/afs-core/src/main/java/com/powsybl/afs/ProjectFileListener.java
+++ b/afs-core/src/main/java/com/powsybl/afs/ProjectFileListener.java
@@ -7,7 +7,7 @@
 package com.powsybl.afs;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface ProjectFileListener {
 

--- a/afs-core/src/main/java/com/powsybl/afs/ProjectFolder.java
+++ b/afs-core/src/main/java/com/powsybl/afs/ProjectFolder.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
  * <p>
  * Project folders may have children project folders or files, and provides methods to create new children.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ProjectFolder extends ProjectNode implements FolderBase<ProjectNode, ProjectFolder> {
 

--- a/afs-core/src/main/java/com/powsybl/afs/ProjectFolderListener.java
+++ b/afs-core/src/main/java/com/powsybl/afs/ProjectFolderListener.java
@@ -7,7 +7,7 @@
 package com.powsybl.afs;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface ProjectFolderListener {
 

--- a/afs-core/src/main/java/com/powsybl/afs/ProjectNode.java
+++ b/afs-core/src/main/java/com/powsybl/afs/ProjectNode.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ProjectNode extends AbstractNodeBase<ProjectFolder> {
 

--- a/afs-core/src/main/java/com/powsybl/afs/SecurityTokenProvider.java
+++ b/afs-core/src/main/java/com/powsybl/afs/SecurityTokenProvider.java
@@ -7,7 +7,7 @@
 package com.powsybl.afs;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface SecurityTokenProvider {
 

--- a/afs-core/src/main/java/com/powsybl/afs/ServiceCreationContext.java
+++ b/afs-core/src/main/java/com/powsybl/afs/ServiceCreationContext.java
@@ -7,7 +7,7 @@
 package com.powsybl.afs;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ServiceCreationContext {
 

--- a/afs-core/src/main/java/com/powsybl/afs/ServiceExtension.java
+++ b/afs-core/src/main/java/com/powsybl/afs/ServiceExtension.java
@@ -17,7 +17,7 @@ import java.util.Objects;
  * Therefore you may only have one local and one remote implementation of the same service registered with your AFS.
  *
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface ServiceExtension<U> {
 

--- a/afs-core/src/main/java/com/powsybl/afs/SoutAppLogger.java
+++ b/afs-core/src/main/java/com/powsybl/afs/SoutAppLogger.java
@@ -10,7 +10,7 @@ import java.io.PrintStream;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class SoutAppLogger implements AppLogger {
 

--- a/afs-core/src/main/java/com/powsybl/afs/SoutTaskListener.java
+++ b/afs-core/src/main/java/com/powsybl/afs/SoutTaskListener.java
@@ -10,7 +10,7 @@ import java.io.PrintStream;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class SoutTaskListener implements TaskListener {
 

--- a/afs-core/src/main/java/com/powsybl/afs/StartTaskEvent.java
+++ b/afs-core/src/main/java/com/powsybl/afs/StartTaskEvent.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class StartTaskEvent extends TaskEvent {
 

--- a/afs-core/src/main/java/com/powsybl/afs/StopTaskEvent.java
+++ b/afs-core/src/main/java/com/powsybl/afs/StopTaskEvent.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class StopTaskEvent extends TaskEvent {
 

--- a/afs-core/src/main/java/com/powsybl/afs/TaskCancellableStatusChangeEvent.java
+++ b/afs-core/src/main/java/com/powsybl/afs/TaskCancellableStatusChangeEvent.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 /**
- * @author Paul Bui-Quang <paul.buiquang at rte-france.com>
+ * @author Paul Bui-Quang {@literal <paul.buiquang at rte-france.com>}
  */
 public class TaskCancellableStatusChangeEvent extends TaskEvent {
 

--- a/afs-core/src/main/java/com/powsybl/afs/TaskEvent.java
+++ b/afs-core/src/main/java/com/powsybl/afs/TaskEvent.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS, include = JsonTypeInfo.As.PROPERTY)
 public class TaskEvent {

--- a/afs-core/src/main/java/com/powsybl/afs/TaskListener.java
+++ b/afs-core/src/main/java/com/powsybl/afs/TaskListener.java
@@ -7,7 +7,7 @@
 package com.powsybl.afs;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface TaskListener {
 

--- a/afs-core/src/main/java/com/powsybl/afs/TaskMonitor.java
+++ b/afs-core/src/main/java/com/powsybl/afs/TaskMonitor.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 import java.util.concurrent.Future;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface TaskMonitor extends AutoCloseable {
 

--- a/afs-core/src/main/java/com/powsybl/afs/TaskMonitorLogger.java
+++ b/afs-core/src/main/java/com/powsybl/afs/TaskMonitorLogger.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class TaskMonitorLogger implements AppLogger {
 

--- a/afs-core/src/main/java/com/powsybl/afs/UnknownFile.java
+++ b/afs-core/src/main/java/com/powsybl/afs/UnknownFile.java
@@ -9,7 +9,7 @@ package com.powsybl.afs;
 /**
  * Represents a file object of an unknown type (for instance when trying to read a file of type unknown to your instance of AFS).
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class UnknownFile extends File {
 

--- a/afs-core/src/main/java/com/powsybl/afs/UnknownProjectFile.java
+++ b/afs-core/src/main/java/com/powsybl/afs/UnknownProjectFile.java
@@ -10,7 +10,7 @@ package com.powsybl.afs;
  *
  * Represents a project file object of an unknown type (for instance when trying to read a file of type unknown to your instance of AFS).
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class UnknownProjectFile extends ProjectFile {
 

--- a/afs-core/src/main/java/com/powsybl/afs/UpdateTaskMessageEvent.java
+++ b/afs-core/src/main/java/com/powsybl/afs/UpdateTaskMessageEvent.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class UpdateTaskMessageEvent extends TaskEvent {
 

--- a/afs-core/src/test/java/com/powsybl/afs/AbstractProjectFileTest.java
+++ b/afs-core/src/test/java/com/powsybl/afs/AbstractProjectFileTest.java
@@ -19,7 +19,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractProjectFileTest {
 

--- a/afs-core/src/test/java/com/powsybl/afs/AfsBaseTest.java
+++ b/afs-core/src/test/java/com/powsybl/afs/AfsBaseTest.java
@@ -40,7 +40,7 @@ import java.util.function.BiConsumer;
 import static org.junit.Assert.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AfsBaseTest {
 

--- a/afs-core/src/test/java/com/powsybl/afs/AppFileSystemToolTest.java
+++ b/afs-core/src/test/java/com/powsybl/afs/AppFileSystemToolTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AppFileSystemToolTest extends AbstractToolTest {
 

--- a/afs-core/src/test/java/com/powsybl/afs/DependencyCacheTest.java
+++ b/afs-core/src/test/java/com/powsybl/afs/DependencyCacheTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.*;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class DependencyCacheTest extends AbstractProjectFileTest {
 

--- a/afs-core/src/test/java/com/powsybl/afs/FooFile.java
+++ b/afs-core/src/test/java/com/powsybl/afs/FooFile.java
@@ -8,7 +8,7 @@ package com.powsybl.afs;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class FooFile extends ProjectFile {
 

--- a/afs-core/src/test/java/com/powsybl/afs/FooFileBuilder.java
+++ b/afs-core/src/test/java/com/powsybl/afs/FooFileBuilder.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class FooFileBuilder implements ProjectFileBuilder<FooFile> {
 

--- a/afs-core/src/test/java/com/powsybl/afs/FooFileExtension.java
+++ b/afs-core/src/test/java/com/powsybl/afs/FooFileExtension.java
@@ -8,7 +8,7 @@ package com.powsybl.afs;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class FooFileExtension implements ProjectFileExtension<FooFile, FooFileBuilder> {
     @Override

--- a/afs-core/src/test/java/com/powsybl/afs/LocalTaskMonitorTest.java
+++ b/afs-core/src/test/java/com/powsybl/afs/LocalTaskMonitorTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.Assert.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LocalTaskMonitorTest extends AbstractProjectFileTest {
 

--- a/afs-core/src/test/java/com/powsybl/afs/ProjectTest.java
+++ b/afs-core/src/test/java/com/powsybl/afs/ProjectTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.*;
 import java.io.IOException;
 
 /**
- * @author Amira KAHYA <amira.kahya at rte-france.com>
+ * @author Amira KAHYA {@literal <amira.kahya at rte-france.com>}
  */
 public class ProjectTest {
     private static final String FOLDER_PSEUDO_CLASS = "folder";

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/AbstractModificationScript.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/AbstractModificationScript.java
@@ -11,7 +11,7 @@ package com.powsybl.afs.ext.base;
 import com.powsybl.afs.ProjectFileCreationContext;
 
 /**
- * @author Paul Bui-Quang <paul.buiquang at rte-france.com>
+ * @author Paul Bui-Quang {@literal <paul.buiquang at rte-france.com>}
  */
 @Deprecated
 public abstract class AbstractModificationScript extends AbstractScript<AbstractModificationScript> {

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/AbstractScript.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/AbstractScript.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractScript<T extends AbstractScript> extends ProjectFile implements StorableScript {
 

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/Case.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/Case.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 /**
  * A type of {@code File} which represents a {@link com.powsybl.iidm.network.Network}.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class Case extends File {
 

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/CaseExtension.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/CaseExtension.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 /**
  * Defines the new type of file {@link Case}.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(FileExtension.class)
 public class CaseExtension implements FileExtension<Case> {

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/GenericScript.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/GenericScript.java
@@ -11,7 +11,7 @@ import com.powsybl.afs.ProjectFileCreationContext;
 /**
  * Default general purpose Groovy script
  *
- * @author Paul Bui-Quang <paul.buiquang at rte-france.com>
+ * @author Paul Bui-Quang {@literal <paul.buiquang at rte-france.com>}
  */
 public class GenericScript extends AbstractScript<GenericScript> {
     public static final String PSEUDO_CLASS = "genericScript";

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/GenericScriptBuilder.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/GenericScriptBuilder.java
@@ -22,7 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 /**
- * @author Paul Bui-Quang <paul.buiquang at rte-france.com>
+ * @author Paul Bui-Quang {@literal <paul.buiquang at rte-france.com>}
  */
 public class GenericScriptBuilder implements ProjectFileBuilder<GenericScript> {
 

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/GenericScriptExtension.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/GenericScriptExtension.java
@@ -14,7 +14,7 @@ import com.powsybl.afs.ProjectFileCreationContext;
 import com.powsybl.afs.ProjectFileExtension;
 
 /**
- * @author Paul Bui-Quang <paul.buiquang at rte-france.com>
+ * @author Paul Bui-Quang {@literal <paul.buiquang at rte-france.com>}
  */
 @AutoService(ProjectFileExtension.class)
 public class GenericScriptExtension implements ProjectFileExtension<GenericScript, GenericScriptBuilder> {

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ImportedCaseBuilder.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ImportedCaseBuilder.java
@@ -36,7 +36,7 @@ import java.util.Properties;
 /**
  * Builder for the project file {@link ImportedCase}.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ImportedCaseBuilder implements ProjectFileBuilder<ImportedCase> {
 

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ImportedCaseExtension.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ImportedCaseExtension.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 /**
  * Defines the new type of project file {@link ImportedCase}.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(ProjectFileExtension.class)
 public class ImportedCaseExtension implements ProjectFileExtension<ImportedCase, ImportedCaseBuilder> {

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/LocalNetworkCacheService.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/LocalNetworkCacheService.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LocalNetworkCacheService implements NetworkCacheService {
 

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/LocalNetworkCacheServiceExtension.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/LocalNetworkCacheServiceExtension.java
@@ -11,7 +11,7 @@ import com.powsybl.afs.ServiceCreationContext;
 import com.powsybl.afs.ServiceExtension;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(ServiceExtension.class)
 public class LocalNetworkCacheServiceExtension implements ServiceExtension<NetworkCacheService> {

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ModificationScript.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ModificationScript.java
@@ -9,7 +9,7 @@ package com.powsybl.afs.ext.base;
 import com.powsybl.afs.ProjectFileCreationContext;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ModificationScript extends AbstractScript<ModificationScript> {
 

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ModificationScriptBuilder.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ModificationScriptBuilder.java
@@ -20,7 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ModificationScriptBuilder implements ProjectFileBuilder<ModificationScript> {
 

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ModificationScriptExtension.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ModificationScriptExtension.java
@@ -12,7 +12,7 @@ import com.powsybl.afs.ProjectFileCreationContext;
 import com.powsybl.afs.ProjectFileExtension;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(ProjectFileExtension.class)
 public class ModificationScriptExtension implements ProjectFileExtension<ModificationScript, ModificationScriptBuilder> {

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/NetworkCacheService.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/NetworkCacheService.java
@@ -16,7 +16,7 @@ import java.util.List;
 /**
  * Provides caching capabilities for loaded {@code Network} objects.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface NetworkCacheService {
 

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ProjectCase.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ProjectCase.java
@@ -14,7 +14,7 @@ import java.util.List;
 /**
  * Common interface for project files able to provide a Network.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface ProjectCase {
 

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ProjectCaseListener.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ProjectCaseListener.java
@@ -7,7 +7,7 @@
 package com.powsybl.afs.ext.base;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface ProjectCaseListener {
 

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ScriptCache.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ScriptCache.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ScriptCache<F extends ProjectFile, V, L> {
 

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ScriptError.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ScriptError.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ScriptError implements Serializable {
 

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ScriptException.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ScriptException.java
@@ -17,7 +17,7 @@ import java.util.ResourceBundle;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ScriptException extends PowsyblException {
 

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ScriptListener.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ScriptListener.java
@@ -7,7 +7,7 @@
 package com.powsybl.afs.ext.base;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface ScriptListener {
 

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ScriptResult.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ScriptResult.java
@@ -12,7 +12,7 @@ import java.util.Objects;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ScriptResult<T> {
 

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ScriptType.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ScriptType.java
@@ -7,7 +7,7 @@
 package com.powsybl.afs.ext.base;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum ScriptType {
     GROOVY

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ScriptUtils.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ScriptUtils.java
@@ -18,7 +18,7 @@ import java.io.*;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class ScriptUtils {
 

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/StorableScript.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/StorableScript.java
@@ -8,7 +8,7 @@ package com.powsybl.afs.ext.base;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface StorableScript {
 

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/VirtualCase.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/VirtualCase.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class VirtualCase extends ProjectFile implements ProjectCase {
 

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/VirtualCaseBuilder.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/VirtualCaseBuilder.java
@@ -14,7 +14,7 @@ import com.powsybl.afs.storage.NodeInfo;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class VirtualCaseBuilder implements ProjectFileBuilder<VirtualCase> {
 

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/VirtualCaseExtension.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/VirtualCaseExtension.java
@@ -12,7 +12,7 @@ import com.powsybl.afs.ProjectFileCreationContext;
 import com.powsybl.afs.ProjectFileExtension;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(ProjectFileExtension.class)
 public class VirtualCaseExtension implements ProjectFileExtension<VirtualCase, VirtualCaseBuilder> {

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/events/BusinessEvent.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/events/BusinessEvent.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.powsybl.afs.storage.events.NodeEvent;
 /**
- * @author Chamseddine Benhamed <chamseddine.benhamed at rte-france.com>
+ * @author Chamseddine Benhamed {@literal <chamseddine.benhamed at rte-france.com>}
  */
 
 public class BusinessEvent extends NodeEvent {

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/events/CaseImported.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/events/CaseImported.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 /**
- * @author Chamseddine Benhamed <chamseddine.benhamed at rte-france.com>
+ * @author Chamseddine Benhamed {@literal <chamseddine.benhamed at rte-france.com>}
  */
 public class CaseImported extends BusinessEvent {
 

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/events/ScriptModified.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/events/ScriptModified.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 /**
- * @author Chamseddine Benhamed <chamseddine.benhamed at rte-france.com>
+ * @author Chamseddine Benhamed {@literal <chamseddine.benhamed at rte-france.com>}
  */
 public class ScriptModified extends BusinessEvent {
 

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/events/VirtualCaseCreated.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/events/VirtualCaseCreated.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 /**
- * @author Chamseddine Benhamed <chamseddine.benhamed at rte-france.com>
+ * @author Chamseddine Benhamed {@literal <chamseddine.benhamed at rte-france.com>}
  */
 public class VirtualCaseCreated extends BusinessEvent {
 

--- a/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/EventsTest.java
+++ b/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/EventsTest.java
@@ -17,7 +17,7 @@ import java.nio.file.Paths;
 import static org.junit.Assert.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class EventsTest {
 

--- a/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/ImportedCaseTest.java
+++ b/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/ImportedCaseTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ImportedCaseTest extends AbstractProjectFileTest {
 

--- a/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/ModificationScriptTest.java
+++ b/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/ModificationScriptTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.Assert.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ModificationScriptTest extends AbstractProjectFileTest {
 

--- a/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/TestImporter.java
+++ b/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/TestImporter.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 import java.util.Properties;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class TestImporter implements Importer {
 

--- a/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/VirtualCaseTest.java
+++ b/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/VirtualCaseTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class VirtualCaseTest extends AbstractProjectFileTest {
 

--- a/afs-local/src/main/java/com/powsybl/afs/local/LocalAppFileSystem.java
+++ b/afs-local/src/main/java/com/powsybl/afs/local/LocalAppFileSystem.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LocalAppFileSystem extends AppFileSystem {
 

--- a/afs-local/src/main/java/com/powsybl/afs/local/LocalAppFileSystemConfig.java
+++ b/afs-local/src/main/java/com/powsybl/afs/local/LocalAppFileSystemConfig.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 import java.util.OptionalInt;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LocalAppFileSystemConfig extends AbstractAppFileSystemConfig<LocalAppFileSystemConfig> {
 

--- a/afs-local/src/main/java/com/powsybl/afs/local/LocalAppFileSystemProvider.java
+++ b/afs-local/src/main/java/com/powsybl/afs/local/LocalAppFileSystemProvider.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(AppFileSystemProvider.class)
 public class LocalAppFileSystemProvider implements AppFileSystemProvider {

--- a/afs-local/src/main/java/com/powsybl/afs/local/storage/DefaultLocalFolder.java
+++ b/afs-local/src/main/java/com/powsybl/afs/local/storage/DefaultLocalFolder.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class DefaultLocalFolder implements LocalFolder {
 

--- a/afs-local/src/main/java/com/powsybl/afs/local/storage/DefaultLocalFolderScanner.java
+++ b/afs-local/src/main/java/com/powsybl/afs/local/storage/DefaultLocalFolderScanner.java
@@ -13,7 +13,7 @@ import java.nio.file.Path;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class DefaultLocalFolderScanner implements LocalFolderScanner {
 

--- a/afs-local/src/main/java/com/powsybl/afs/local/storage/LocalAppStorage.java
+++ b/afs-local/src/main/java/com/powsybl/afs/local/storage/LocalAppStorage.java
@@ -27,7 +27,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LocalAppStorage extends AbstractAppStorage {
 

--- a/afs-local/src/main/java/com/powsybl/afs/local/storage/LocalCase.java
+++ b/afs-local/src/main/java/com/powsybl/afs/local/storage/LocalCase.java
@@ -26,7 +26,7 @@ import java.util.*;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LocalCase implements LocalFile {
 

--- a/afs-local/src/main/java/com/powsybl/afs/local/storage/LocalCaseScanner.java
+++ b/afs-local/src/main/java/com/powsybl/afs/local/storage/LocalCaseScanner.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(LocalFileScanner.class)
 public class LocalCaseScanner implements LocalFileScanner {

--- a/afs-local/src/main/java/com/powsybl/afs/local/storage/LocalFile.java
+++ b/afs-local/src/main/java/com/powsybl/afs/local/storage/LocalFile.java
@@ -17,7 +17,7 @@ import java.util.Set;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface LocalFile extends LocalNode {
 

--- a/afs-local/src/main/java/com/powsybl/afs/local/storage/LocalFileScanner.java
+++ b/afs-local/src/main/java/com/powsybl/afs/local/storage/LocalFileScanner.java
@@ -10,7 +10,7 @@ import java.nio.file.Path;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface LocalFileScanner {
 

--- a/afs-local/src/main/java/com/powsybl/afs/local/storage/LocalFileScannerContext.java
+++ b/afs-local/src/main/java/com/powsybl/afs/local/storage/LocalFileScannerContext.java
@@ -10,7 +10,7 @@ import com.powsybl.computation.ComputationManager;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LocalFileScannerContext {
 

--- a/afs-local/src/main/java/com/powsybl/afs/local/storage/LocalFolder.java
+++ b/afs-local/src/main/java/com/powsybl/afs/local/storage/LocalFolder.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface LocalFolder extends LocalNode {
 

--- a/afs-local/src/main/java/com/powsybl/afs/local/storage/LocalFolderScanner.java
+++ b/afs-local/src/main/java/com/powsybl/afs/local/storage/LocalFolderScanner.java
@@ -10,7 +10,7 @@ import java.nio.file.Path;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface LocalFolderScanner {
 

--- a/afs-local/src/main/java/com/powsybl/afs/local/storage/LocalFolderScannerContext.java
+++ b/afs-local/src/main/java/com/powsybl/afs/local/storage/LocalFolderScannerContext.java
@@ -12,7 +12,7 @@ import java.nio.file.Path;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LocalFolderScannerContext {
 

--- a/afs-local/src/main/java/com/powsybl/afs/local/storage/LocalNode.java
+++ b/afs-local/src/main/java/com/powsybl/afs/local/storage/LocalNode.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 /**
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface LocalNode {
 

--- a/afs-local/src/test/java/com/powsybl/afs/local/LocalAppFileSystemConfigTest.java
+++ b/afs-local/src/test/java/com/powsybl/afs/local/LocalAppFileSystemConfigTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import static org.junit.Assert.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LocalAppFileSystemConfigTest {
 

--- a/afs-local/src/test/java/com/powsybl/afs/local/LocalAppFileSystemProviderTest.java
+++ b/afs-local/src/test/java/com/powsybl/afs/local/LocalAppFileSystemProviderTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LocalAppFileSystemProviderTest {
 

--- a/afs-local/src/test/java/com/powsybl/afs/local/storage/LocalAppStorageTest.java
+++ b/afs-local/src/test/java/com/powsybl/afs/local/storage/LocalAppStorageTest.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LocalAppStorageTest {
 

--- a/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/DoubleDataChunkSerializer.java
+++ b/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/DoubleDataChunkSerializer.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 import java.io.Serializable;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class DoubleDataChunkSerializer implements Serializer<DoubleDataChunk>, Serializable {
 

--- a/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/MapDbAppStorage.java
+++ b/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/MapDbAppStorage.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class MapDbAppStorage extends AbstractAppStorage {
 

--- a/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/MapDbStorageConstants.java
+++ b/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/MapDbStorageConstants.java
@@ -7,7 +7,7 @@
 package com.powsybl.afs.mapdb.storage;
 
 /**
- * @author Nicolas Noir <nicolas.noir at rte-france.com>
+ * @author Nicolas Noir {@literal <nicolas.noir at rte-france.com>}
  */
 public final class MapDbStorageConstants {
 

--- a/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/NamedLink.java
+++ b/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/NamedLink.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NamedLink {
 

--- a/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/NamedLinkListSerializer.java
+++ b/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/NamedLinkListSerializer.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class NamedLinkListSerializer implements Serializer<List<NamedLink>>, Serializable {
 

--- a/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/NamedLinkSerializer.java
+++ b/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/NamedLinkSerializer.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 import java.io.Serializable;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NamedLinkSerializer implements Serializer<NamedLink>, Serializable {
 

--- a/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/NodeInfoSerializer.java
+++ b/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/NodeInfoSerializer.java
@@ -17,7 +17,7 @@ import java.io.Serializable;
 import java.util.Map;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodeInfoSerializer implements Serializer<NodeInfo>, Serializable {
 

--- a/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/StringDataChunkSerializer.java
+++ b/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/StringDataChunkSerializer.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 import java.io.Serializable;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class StringDataChunkSerializer implements Serializer<StringDataChunk>, Serializable {
 

--- a/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/StringSetSerializer.java
+++ b/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/StringSetSerializer.java
@@ -16,7 +16,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class StringSetSerializer implements Serializer<Set<String>>, Serializable {
 

--- a/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/TimeSeriesChunkKey.java
+++ b/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/TimeSeriesChunkKey.java
@@ -9,7 +9,7 @@ package com.powsybl.afs.mapdb.storage;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class TimeSeriesChunkKey {
 

--- a/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/TimeSeriesChunkKeySerializer.java
+++ b/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/TimeSeriesChunkKeySerializer.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 import java.io.Serializable;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class TimeSeriesChunkKeySerializer implements Serializer<TimeSeriesChunkKey>, Serializable {
 

--- a/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/TimeSeriesIndexSerializer.java
+++ b/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/TimeSeriesIndexSerializer.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 import java.io.Serializable;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class TimeSeriesIndexSerializer implements Serializer<TimeSeriesIndex>, Serializable {
 

--- a/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/TimeSeriesKey.java
+++ b/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/TimeSeriesKey.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class TimeSeriesKey {
 

--- a/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/TimeSeriesKeySerializer.java
+++ b/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/TimeSeriesKeySerializer.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 import java.io.Serializable;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class TimeSeriesKeySerializer implements Serializer<TimeSeriesKey>, Serializable {
 

--- a/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/TimeSeriesMetadataSerializer.java
+++ b/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/TimeSeriesMetadataSerializer.java
@@ -19,7 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class TimeSeriesMetadataSerializer implements Serializer<TimeSeriesMetadata>, Serializable {
 

--- a/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/UuidListSerializer.java
+++ b/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/UuidListSerializer.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class UuidListSerializer implements Serializer<List<UUID>>, Serializable {
 

--- a/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/UuidSerializer.java
+++ b/afs-mapdb-storage/src/main/java/com/powsybl/afs/mapdb/storage/UuidSerializer.java
@@ -15,7 +15,7 @@ import java.io.Serializable;
 import java.util.UUID;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class UuidSerializer implements Serializer<UUID>, Serializable {
 

--- a/afs-mapdb-storage/src/test/java/com/powsybl/afs/mapdb/storage/ForwardingAppStorageTest.java
+++ b/afs-mapdb-storage/src/test/java/com/powsybl/afs/mapdb/storage/ForwardingAppStorageTest.java
@@ -12,7 +12,7 @@ import com.powsybl.afs.storage.ForwardingAppStorage;
 import com.powsybl.afs.storage.InMemoryEventsBus;
 
 /**
- * @author Chamseddine Benhamed <chamseddine.benhamed at rte-france.com>
+ * @author Chamseddine Benhamed {@literal <chamseddine.benhamed at rte-france.com>}
  */
 public class ForwardingAppStorageTest extends AbstractAppStorageTest {
 

--- a/afs-mapdb-storage/src/test/java/com/powsybl/afs/mapdb/storage/MapDbAppStorageArchiveTest.java
+++ b/afs-mapdb-storage/src/test/java/com/powsybl/afs/mapdb/storage/MapDbAppStorageArchiveTest.java
@@ -11,7 +11,7 @@ import com.powsybl.afs.storage.AppStorage;
 import com.powsybl.afs.storage.InMemoryEventsBus;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class MapDbAppStorageArchiveTest extends AbstractAppStorageArchiveTest {
 

--- a/afs-mapdb-storage/src/test/java/com/powsybl/afs/mapdb/storage/MapDbAppStorageTest.java
+++ b/afs-mapdb-storage/src/test/java/com/powsybl/afs/mapdb/storage/MapDbAppStorageTest.java
@@ -11,7 +11,7 @@ import com.powsybl.afs.storage.AppStorage;
 import com.powsybl.afs.storage.InMemoryEventsBus;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class MapDbAppStorageTest extends AbstractAppStorageTest {
 

--- a/afs-mapdb/src/main/java/com/powsybl/afs/mapdb/MapDbAppFileSystem.java
+++ b/afs-mapdb/src/main/java/com/powsybl/afs/mapdb/MapDbAppFileSystem.java
@@ -10,7 +10,7 @@ import com.powsybl.afs.AppFileSystem;
 import com.powsybl.afs.mapdb.storage.MapDbAppStorage;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class MapDbAppFileSystem extends AppFileSystem {
 

--- a/afs-mapdb/src/main/java/com/powsybl/afs/mapdb/MapDbAppFileSystemConfig.java
+++ b/afs-mapdb/src/main/java/com/powsybl/afs/mapdb/MapDbAppFileSystemConfig.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class MapDbAppFileSystemConfig extends AbstractAppFileSystemConfig<MapDbAppFileSystemConfig> {
 

--- a/afs-mapdb/src/main/java/com/powsybl/afs/mapdb/MapDbAppFileSystemProvider.java
+++ b/afs-mapdb/src/main/java/com/powsybl/afs/mapdb/MapDbAppFileSystemProvider.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(AppFileSystemProvider.class)
 public class MapDbAppFileSystemProvider implements AppFileSystemProvider {

--- a/afs-mapdb/src/test/java/com/powsybl/afs/mapdb/MapDbAppFileSystemConfigTest.java
+++ b/afs-mapdb/src/test/java/com/powsybl/afs/mapdb/MapDbAppFileSystemConfigTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import static org.junit.Assert.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class MapDbAppFileSystemConfigTest {
 

--- a/afs-mapdb/src/test/java/com/powsybl/afs/mapdb/MapDbAppFileSystemProviderTest.java
+++ b/afs-mapdb/src/test/java/com/powsybl/afs/mapdb/MapDbAppFileSystemProviderTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class MapDbAppFileSystemProviderTest {
 

--- a/afs-network/afs-network-client/src/main/java/com/powsybl/afs/network/client/RemoteNetworkCacheService.java
+++ b/afs-network/afs-network-client/src/main/java/com/powsybl/afs/network/client/RemoteNetworkCacheService.java
@@ -39,7 +39,7 @@ import static com.powsybl.afs.ws.client.utils.ClientUtils.checkOk;
 import static com.powsybl.afs.ws.client.utils.ClientUtils.readEntityIfOk;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class RemoteNetworkCacheService implements NetworkCacheService {
 

--- a/afs-network/afs-network-client/src/main/java/com/powsybl/afs/network/client/RemoteNetworkCacheServiceExtension.java
+++ b/afs-network/afs-network-client/src/main/java/com/powsybl/afs/network/client/RemoteNetworkCacheServiceExtension.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(ServiceExtension.class)
 public class RemoteNetworkCacheServiceExtension implements ServiceExtension<NetworkCacheService> {

--- a/afs-network/afs-network-client/src/test/java/com/powsybl/afs/network/client/CodeCoverage.java
+++ b/afs-network/afs-network-client/src/test/java/com/powsybl/afs/network/client/CodeCoverage.java
@@ -9,7 +9,7 @@ package com.powsybl.afs.network.client;
 import org.junit.Test;
 
 /**
- * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ * @author Mathieu Bague {@literal <mathieu.bague at rte-france.com>}
  */
 public class CodeCoverage {
 

--- a/afs-network/afs-network-server/src/main/java/com/powsybl/afs/network/server/NetworkCacheApplication.java
+++ b/afs-network/afs-network-server/src/main/java/com/powsybl/afs/network/server/NetworkCacheApplication.java
@@ -10,7 +10,7 @@ import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @ApplicationPath("/rest")
 public class NetworkCacheApplication extends Application {

--- a/afs-network/afs-network-server/src/main/java/com/powsybl/afs/network/server/NetworkCacheServer.java
+++ b/afs-network/afs-network-server/src/main/java/com/powsybl/afs/network/server/NetworkCacheServer.java
@@ -23,7 +23,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @Named
 @ApplicationScoped

--- a/afs-network/afs-network-server/src/test/java/com/powsybl/afs/network/server/CodeCoverage.java
+++ b/afs-network/afs-network-server/src/test/java/com/powsybl/afs/network/server/CodeCoverage.java
@@ -9,7 +9,7 @@ package com.powsybl.afs.network.server;
 import org.junit.Test;
 
 /**
- * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ * @author Mathieu Bague {@literal <mathieu.bague at rte-france.com>}
  */
 public class CodeCoverage {
 

--- a/afs-scripting/src/main/groovy/com/powsybl/afs/scripting/AfsGroovyExtensionModule.groovy
+++ b/afs-scripting/src/main/groovy/com/powsybl/afs/scripting/AfsGroovyExtensionModule.groovy
@@ -13,7 +13,7 @@ import com.powsybl.afs.ProjectFileExtension
 import com.powsybl.afs.ProjectFolder
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class AfsGroovyExtensionModule {
 

--- a/afs-scripting/src/main/groovy/com/powsybl/afs/scripting/AfsGroovyFacade.groovy
+++ b/afs-scripting/src/main/groovy/com/powsybl/afs/scripting/AfsGroovyFacade.groovy
@@ -12,7 +12,7 @@ import com.powsybl.afs.Folder
 import java.util.stream.Collectors
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class AfsGroovyFacade {
 

--- a/afs-scripting/src/main/groovy/com/powsybl/afs/scripting/AfsGroovyScriptExtension.groovy
+++ b/afs-scripting/src/main/groovy/com/powsybl/afs/scripting/AfsGroovyScriptExtension.groovy
@@ -20,7 +20,7 @@ import com.powsybl.computation.DefaultComputationManagerConfig
 import com.powsybl.scripting.groovy.GroovyScriptExtension
 
 /**
- * @author Mathieu BAGUE <mathieu.bague at rte-france.com>
+ * @author Mathieu BAGUE {@literal <mathieu.bague at rte-france.com>}
  */
 @AutoService(GroovyScriptExtension.class)
 class AfsGroovyScriptExtension implements GroovyScriptExtension {

--- a/afs-scripting/src/main/groovy/com/powsybl/afs/scripting/BuilderSpec.groovy
+++ b/afs-scripting/src/main/groovy/com/powsybl/afs/scripting/BuilderSpec.groovy
@@ -3,7 +3,7 @@ package com.powsybl.afs.scripting
 import com.powsybl.afs.AfsException
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 class BuilderSpec {
 

--- a/afs-scripting/src/test/java/com/powsybl/afs/scripting/AbstractGroovyScriptTest.java
+++ b/afs-scripting/src/test/java/com/powsybl/afs/scripting/AbstractGroovyScriptTest.java
@@ -31,7 +31,7 @@ import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractGroovyScriptTest {
 

--- a/afs-scripting/src/test/java/com/powsybl/afs/scripting/AfsExtensionErrorGroovyScriptTest.java
+++ b/afs-scripting/src/test/java/com/powsybl/afs/scripting/AfsExtensionErrorGroovyScriptTest.java
@@ -17,7 +17,7 @@ import java.io.Reader;
 import java.io.StringReader;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AfsExtensionErrorGroovyScriptTest extends AbstractGroovyScriptTest {
 

--- a/afs-scripting/src/test/java/com/powsybl/afs/scripting/AfsExtensionGroovyScriptTest.java
+++ b/afs-scripting/src/test/java/com/powsybl/afs/scripting/AfsExtensionGroovyScriptTest.java
@@ -18,7 +18,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AfsExtensionGroovyScriptTest extends AbstractGroovyScriptTest {
 

--- a/afs-scripting/src/test/java/com/powsybl/afs/scripting/AfsGroovyScriptTest.java
+++ b/afs-scripting/src/test/java/com/powsybl/afs/scripting/AfsGroovyScriptTest.java
@@ -14,7 +14,7 @@ import java.io.Reader;
 import java.io.StringReader;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AfsGroovyScriptTest extends AbstractGroovyScriptTest {
 

--- a/afs-scripting/src/test/java/com/powsybl/afs/scripting/HelloGroovyScriptTest.java
+++ b/afs-scripting/src/test/java/com/powsybl/afs/scripting/HelloGroovyScriptTest.java
@@ -10,7 +10,7 @@ import java.io.Reader;
 import java.io.StringReader;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class HelloGroovyScriptTest extends AbstractGroovyScriptTest {
 

--- a/afs-security-analysis-local/src/main/java/com/powsybl/afs/security/local/LocalSecurityAnalysisRunningService.java
+++ b/afs-security-analysis-local/src/main/java/com/powsybl/afs/security/local/LocalSecurityAnalysisRunningService.java
@@ -26,7 +26,7 @@ import com.powsybl.security.interceptors.SecurityAnalysisInterceptors;
 import java.util.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class LocalSecurityAnalysisRunningService implements SecurityAnalysisRunningService {
 

--- a/afs-security-analysis-local/src/main/java/com/powsybl/afs/security/local/LocalSecurityAnalysisRunningServiceExtension.java
+++ b/afs-security-analysis-local/src/main/java/com/powsybl/afs/security/local/LocalSecurityAnalysisRunningServiceExtension.java
@@ -15,7 +15,7 @@ import com.powsybl.security.SecurityAnalysis;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(ServiceExtension.class)
 public class LocalSecurityAnalysisRunningServiceExtension implements ServiceExtension<SecurityAnalysisRunningService> {

--- a/afs-security-analysis-local/src/test/java/com/powsybl/afs/security/local/LocalSecurityAnalysisRunningServiceTest.java
+++ b/afs-security-analysis-local/src/test/java/com/powsybl/afs/security/local/LocalSecurityAnalysisRunningServiceTest.java
@@ -18,7 +18,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 /**
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
  */
 public class LocalSecurityAnalysisRunningServiceTest extends SecurityAnalysisRunnerTest {
 

--- a/afs-security-analysis-local/src/test/java/com/powsybl/afs/security/local/SecurityAnalysisProviderMock.java
+++ b/afs-security-analysis-local/src/test/java/com/powsybl/afs/security/local/SecurityAnalysisProviderMock.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
  */
 public class SecurityAnalysisProviderMock implements SecurityAnalysisProvider {
 

--- a/afs-security-analysis/src/main/java/com/powsybl/afs/security/SecurityAnalysisRunner.java
+++ b/afs-security-analysis/src/main/java/com/powsybl/afs/security/SecurityAnalysisRunner.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class SecurityAnalysisRunner extends ProjectFile {
 

--- a/afs-security-analysis/src/main/java/com/powsybl/afs/security/SecurityAnalysisRunnerBuilder.java
+++ b/afs-security-analysis/src/main/java/com/powsybl/afs/security/SecurityAnalysisRunnerBuilder.java
@@ -15,7 +15,7 @@ import com.powsybl.security.SecurityAnalysisParameters;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class SecurityAnalysisRunnerBuilder implements ProjectFileBuilder<SecurityAnalysisRunner> {
 

--- a/afs-security-analysis/src/main/java/com/powsybl/afs/security/SecurityAnalysisRunnerExtension.java
+++ b/afs-security-analysis/src/main/java/com/powsybl/afs/security/SecurityAnalysisRunnerExtension.java
@@ -15,7 +15,7 @@ import com.powsybl.security.SecurityAnalysisParameters;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(ProjectFileExtension.class)
 public class SecurityAnalysisRunnerExtension implements ProjectFileExtension<SecurityAnalysisRunner, SecurityAnalysisRunnerBuilder> {

--- a/afs-security-analysis/src/main/java/com/powsybl/afs/security/SecurityAnalysisRunningService.java
+++ b/afs-security-analysis/src/main/java/com/powsybl/afs/security/SecurityAnalysisRunningService.java
@@ -7,7 +7,7 @@
 package com.powsybl.afs.security;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface SecurityAnalysisRunningService {
 

--- a/afs-security-analysis/src/main/java/com/powsybl/afs/security/SubjectInfoExtension.java
+++ b/afs-security-analysis/src/main/java/com/powsybl/afs/security/SubjectInfoExtension.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class SubjectInfoExtension extends AbstractExtension<LimitViolation> {
 

--- a/afs-security-analysis/src/main/java/com/powsybl/afs/security/SubjectInfoExtensionSerializer.java
+++ b/afs-security-analysis/src/main/java/com/powsybl/afs/security/SubjectInfoExtensionSerializer.java
@@ -22,7 +22,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(ExtensionJsonSerializer.class)
 public class SubjectInfoExtensionSerializer implements ExtensionJsonSerializer<LimitViolation, SubjectInfoExtension> {

--- a/afs-security-analysis/src/main/java/com/powsybl/afs/security/SubjectInfoInterceptor.java
+++ b/afs-security-analysis/src/main/java/com/powsybl/afs/security/SubjectInfoInterceptor.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class SubjectInfoInterceptor extends DefaultSecurityAnalysisInterceptor {
     private void addSubjectInfo(SecurityAnalysisResultContext context, LimitViolationsResult result) {

--- a/afs-security-analysis/src/main/java/com/powsybl/afs/security/SubjectInfoInterceptorExtension.java
+++ b/afs-security-analysis/src/main/java/com/powsybl/afs/security/SubjectInfoInterceptorExtension.java
@@ -10,7 +10,7 @@ import com.google.auto.service.AutoService;
 import com.powsybl.security.interceptors.SecurityAnalysisInterceptorExtension;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(SecurityAnalysisInterceptorExtension.class)
 public class SubjectInfoInterceptorExtension implements SecurityAnalysisInterceptorExtension {

--- a/afs-security-analysis/src/test/java/com/powsybl/afs/security/SecurityAnalysisRunnerTest.java
+++ b/afs-security-analysis/src/test/java/com/powsybl/afs/security/SecurityAnalysisRunnerTest.java
@@ -41,7 +41,7 @@ import java.util.Properties;
 import static org.junit.Assert.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class SecurityAnalysisRunnerTest extends AbstractProjectFileTest {
 

--- a/afs-security-analysis/src/test/java/com/powsybl/afs/security/SubjectInfoExtensionTest.java
+++ b/afs-security-analysis/src/test/java/com/powsybl/afs/security/SubjectInfoExtensionTest.java
@@ -22,7 +22,7 @@ import java.util.TreeSet;
 import static org.junit.Assert.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class SubjectInfoExtensionTest {
 

--- a/afs-security-analysis/src/test/java/com/powsybl/afs/security/SubjectInfoInterceptorTest.java
+++ b/afs-security-analysis/src/test/java/com/powsybl/afs/security/SubjectInfoInterceptorTest.java
@@ -24,7 +24,7 @@ import java.util.Collections;
 import static org.junit.Assert.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class SubjectInfoInterceptorTest {
 

--- a/afs-spring-server/src/main/java/com/powsybl/afs/server/AppDataWrapper.java
+++ b/afs-spring-server/src/main/java/com/powsybl/afs/server/AppDataWrapper.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 /**
  * Wrapper around {@link AppData} which provides additional checks around access to storage and filesystems.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @Component
 public class AppDataWrapper {

--- a/afs-spring-server/src/main/java/com/powsybl/afs/server/events/NodeEventForwarder.java
+++ b/afs-spring-server/src/main/java/com/powsybl/afs/server/events/NodeEventForwarder.java
@@ -18,7 +18,7 @@ import org.springframework.web.socket.WebSocketSession;
 /**
  * A listener which forwards events to a websocket client.
  *
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
  */
 public class NodeEventForwarder implements AppStorageListener {
 

--- a/afs-spring-server/src/main/java/com/powsybl/afs/server/events/NodeEventHandler.java
+++ b/afs-spring-server/src/main/java/com/powsybl/afs/server/events/NodeEventHandler.java
@@ -29,7 +29,7 @@ import java.io.UncheckedIOException;
  *     <li>On receiving events from the client, forwards it to underlying event bus</li>
  * </ul>
  *
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
  */
 public class NodeEventHandler extends TextWebSocketHandler {
 

--- a/afs-spring-server/src/main/java/com/powsybl/afs/server/events/SessionAttributes.java
+++ b/afs-spring-server/src/main/java/com/powsybl/afs/server/events/SessionAttributes.java
@@ -15,7 +15,7 @@ import java.util.Map;
 /**
  * Utility to get/set session attributes.
  *
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
  */
 public class SessionAttributes {
 

--- a/afs-spring-server/src/main/java/com/powsybl/afs/server/events/WebSocketConstants.java
+++ b/afs-spring-server/src/main/java/com/powsybl/afs/server/events/WebSocketConstants.java
@@ -9,7 +9,7 @@ package com.powsybl.afs.server.events;
 /**
  * Constants for web sockets.
  *
- * @author Sylvain Leclerc <sylvain.leclerc@rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc@rte-france.com>}
  */
 public final class WebSocketConstants {
 

--- a/afs-spring-server/src/main/java/com/powsybl/afs/server/events/WebSocketContext.java
+++ b/afs-spring-server/src/main/java/com/powsybl/afs/server/events/WebSocketContext.java
@@ -16,7 +16,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @Component
 public class WebSocketContext implements AutoCloseable {

--- a/afs-spring-server/src/main/java/com/powsybl/afs/server/events/WebSocketUtils.java
+++ b/afs-spring-server/src/main/java/com/powsybl/afs/server/events/WebSocketUtils.java
@@ -12,7 +12,7 @@ import org.springframework.web.socket.handler.ConcurrentWebSocketSessionDecorato
 /**
  * Utilities for web sockets.
  *
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
  */
 public final class WebSocketUtils {
 

--- a/afs-spring-server/src/main/java/com/powsybl/afs/server/io/GzipFilter.java
+++ b/afs-spring-server/src/main/java/com/powsybl/afs/server/io/GzipFilter.java
@@ -26,7 +26,7 @@ import java.io.IOException;
  * the streaming of responses ({@link org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody}.
  * This filter must not be activated on such endpoints.
  *
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
  */
 public class GzipFilter implements Filter {
 

--- a/afs-spring-server/src/main/java/com/powsybl/afs/server/io/GzipFilterRegistration.java
+++ b/afs-spring-server/src/main/java/com/powsybl/afs/server/io/GzipFilterRegistration.java
@@ -13,7 +13,7 @@ import org.springframework.context.annotation.Configuration;
 /**
  * Registers the {@link GzipFilter} only for AFS endpoints.
  *
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
  */
 @Configuration
 public class GzipFilterRegistration {

--- a/afs-spring-server/src/main/java/com/powsybl/afs/server/io/GzippedRequestWrapper.java
+++ b/afs-spring-server/src/main/java/com/powsybl/afs/server/io/GzippedRequestWrapper.java
@@ -16,7 +16,7 @@ import java.util.zip.GZIPInputStream;
 /**
  * Wraps a request to gunzip its content.
  *
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
  */
 public class GzippedRequestWrapper extends HttpServletRequestWrapper {
 

--- a/afs-spring-server/src/main/java/com/powsybl/afs/server/io/GzippedResponseWrapper.java
+++ b/afs-spring-server/src/main/java/com/powsybl/afs/server/io/GzippedResponseWrapper.java
@@ -22,7 +22,7 @@ import org.springframework.http.HttpHeaders;
 /**
  * Wraps a response to gzip its content if its content-encoding is set to "gzip".
  *
- * @author Sylvain Leclerc <sylvain.leclerc at rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc at rte-france.com>}
  */
 public class GzippedResponseWrapper extends HttpServletResponseWrapper {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/AbstractAppFileSystemConfig.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/AbstractAppFileSystemConfig.java
@@ -9,7 +9,7 @@ package com.powsybl.afs.storage;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractAppFileSystemConfig<T extends AbstractAppFileSystemConfig<T>> {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/AbstractAppStorage.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/AbstractAppStorage.java
@@ -11,7 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * @author Chamseddine Benhamed <chamseddine.benhamed at rte-france.com>
+ * @author Chamseddine Benhamed {@literal <chamseddine.benhamed at rte-france.com>}
  */
 public abstract class AbstractAppStorage implements AppStorage {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/AfsStorageException.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/AfsStorageException.java
@@ -9,7 +9,7 @@ package com.powsybl.afs.storage;
 import com.powsybl.commons.PowsyblException;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AfsStorageException extends PowsyblException {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/AppStorage.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/AppStorage.java
@@ -26,7 +26,7 @@ import java.util.*;
  * An AppStorage implements low level methods to walk through a filesystem and to write and read data from this filesystem.
  * It relies on nodes uniquely identified by and ID.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface AppStorage extends AutoCloseable {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/AppStorageArchive.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/AppStorageArchive.java
@@ -39,7 +39,7 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AppStorageArchive {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/AppStorageDataSource.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/AppStorageDataSource.java
@@ -24,7 +24,7 @@ import com.powsybl.commons.datasource.DataSource;
  * A datasource corresponding to a data blob stored in the file system.
  * A data blob is associated to a node and a name identifying it among data blobs of this node.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AppStorageDataSource implements DataSource {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/EventsBus.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/EventsBus.java
@@ -10,7 +10,7 @@ import com.powsybl.afs.storage.events.AppStorageListener;
 import com.powsybl.afs.storage.events.NodeEvent;
 
 /**
- * @author Chamseddine Benhamed <chamseddine.benhamed at rte-france.com>
+ * @author Chamseddine Benhamed {@literal <chamseddine.benhamed at rte-france.com>}
  */
 public interface EventsBus extends AutoCloseable {
     /**

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/ForwardingAppStorage.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/ForwardingAppStorage.java
@@ -19,7 +19,7 @@ import java.util.*;
 /**
  * A storage implementation which simply delegates calls to another underlying AppStorage implementation.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ForwardingAppStorage implements AppStorage {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/InMemoryEventsBus.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/InMemoryEventsBus.java
@@ -21,7 +21,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * @author Chamseddine Benhamed <chamseddine.benhamed at rte-france.com>
+ * @author Chamseddine Benhamed {@literal <chamseddine.benhamed at rte-france.com>}
  */
 public class InMemoryEventsBus implements EventsBus {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/ListenableAppStorage.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/ListenableAppStorage.java
@@ -16,7 +16,7 @@ import com.powsybl.afs.storage.events.AppStorageListener;
  * WARNING: you will need to keep a reference to your listeners,
  *          otherwise they may be garbage collected.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface ListenableAppStorage extends AppStorage {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/NodeDependency.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/NodeDependency.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 /**
  * Represents a named dependency to a node in the tree.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodeDependency {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/NodeGenericMetadata.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/NodeGenericMetadata.java
@@ -14,7 +14,7 @@ import java.util.Objects;
  *
  * Metadata about a particular node. This is a low level object, should seldom be used by AFS API users.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodeGenericMetadata {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/NodeInfo.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/NodeInfo.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 /**
  * Low level information about a node in an AFS tree. Should seldom be used by AFS API users.
  *
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodeInfo {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/Utils.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/Utils.java
@@ -22,7 +22,7 @@ import java.util.zip.ZipOutputStream;
 /**
  * Utility class.
  *
- * @author Valentin Berthault <valentin.berthault at rte-france.com>
+ * @author Valentin Berthault {@literal <valentin.berthault at rte-france.com>}
  */
 public final class Utils {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/buffer/AbstractStorageChange.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/buffer/AbstractStorageChange.java
@@ -9,7 +9,7 @@ package com.powsybl.afs.storage.buffer;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractStorageChange implements StorageChange {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/buffer/AbstractTimeSeriesChunksAddition.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/buffer/AbstractTimeSeriesChunksAddition.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractTimeSeriesChunksAddition<P extends AbstractPoint, T extends DataChunk<P, T>> extends AbstractStorageChange {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/buffer/DoubleTimeSeriesChunksAddition.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/buffer/DoubleTimeSeriesChunksAddition.java
@@ -14,7 +14,7 @@ import com.powsybl.timeseries.DoublePoint;
 import java.util.List;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class DoubleTimeSeriesChunksAddition extends AbstractTimeSeriesChunksAddition<DoublePoint, DoubleDataChunk> {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/buffer/StorageChange.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/buffer/StorageChange.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS, include = JsonTypeInfo.As.PROPERTY)
 public interface StorageChange {

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/buffer/StorageChangeBuffer.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/buffer/StorageChangeBuffer.java
@@ -16,7 +16,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class StorageChangeBuffer {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/buffer/StorageChangeFlusher.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/buffer/StorageChangeFlusher.java
@@ -7,7 +7,7 @@
 package com.powsybl.afs.storage.buffer;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface StorageChangeFlusher {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/buffer/StorageChangeSet.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/buffer/StorageChangeSet.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS, include = JsonTypeInfo.As.PROPERTY)
 public class StorageChangeSet {

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/buffer/StorageChangeType.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/buffer/StorageChangeType.java
@@ -7,7 +7,7 @@
 package com.powsybl.afs.storage.buffer;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public enum StorageChangeType {
     TIME_SERIES_CREATION,

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/buffer/StringTimeSeriesChunksAddition.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/buffer/StringTimeSeriesChunksAddition.java
@@ -14,7 +14,7 @@ import com.powsybl.timeseries.StringPoint;
 import java.util.List;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class StringTimeSeriesChunksAddition extends AbstractTimeSeriesChunksAddition<StringPoint, StringDataChunk> {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/buffer/TimeSeriesCreation.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/buffer/TimeSeriesCreation.java
@@ -13,7 +13,7 @@ import com.powsybl.timeseries.TimeSeriesMetadata;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class TimeSeriesCreation extends AbstractStorageChange {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/check/FileSystemCheckIssue.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/check/FileSystemCheckIssue.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 /**
  * An issue identified during a file system check.
  *
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 public class FileSystemCheckIssue {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/check/FileSystemCheckOptions.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/check/FileSystemCheckOptions.java
@@ -16,7 +16,7 @@ import java.util.Set;
  * Options for a file system check. It defines what types of issues should be looked for,
  * and if they should be repaired or not.
  *
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 public class FileSystemCheckOptions {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/check/FileSystemCheckOptionsBuilder.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/check/FileSystemCheckOptionsBuilder.java
@@ -10,7 +10,7 @@ import java.time.Instant;
 import java.util.*;
 
 /**
- * @author Yichen TANG <yichen.tang at rte-france.com>
+ * @author Yichen TANG {@literal <yichen.tang at rte-france.com>}
  */
 public class FileSystemCheckOptionsBuilder {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/AppStorageListener.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/AppStorageListener.java
@@ -10,7 +10,7 @@ import java.util.Collections;
 import java.util.Set;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface AppStorageListener {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/BackwardDependencyAdded.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/BackwardDependencyAdded.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class BackwardDependencyAdded extends NodeEvent implements DependencyEvent {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/BackwardDependencyRemoved.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/BackwardDependencyRemoved.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class BackwardDependencyRemoved extends NodeEvent implements DependencyEvent {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/DependencyAdded.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/DependencyAdded.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class DependencyAdded extends NodeEvent implements DependencyEvent {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/DependencyEvent.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/DependencyEvent.java
@@ -7,7 +7,7 @@
 package com.powsybl.afs.storage.events;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public interface DependencyEvent {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/DependencyRemoved.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/DependencyRemoved.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class DependencyRemoved extends NodeEvent implements DependencyEvent {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeConsistent.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeConsistent.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 /**
- * @author Benhamed Chamseddine <benhamed.chamseddine at rte-france.com>
+ * @author Benhamed Chamseddine {@literal <benhamed.chamseddine at rte-france.com>}
  */
 public class NodeConsistent extends NodeEvent {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeCreated.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeCreated.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodeCreated extends NodeEvent {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeDataRemoved.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeDataRemoved.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodeDataRemoved extends NodeEvent {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeDataUpdated.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeDataUpdated.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodeDataUpdated extends NodeEvent {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeDescriptionUpdated.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeDescriptionUpdated.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodeDescriptionUpdated extends NodeEvent {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeEvent.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeEvent.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS, include = JsonTypeInfo.As.PROPERTY)
 public class NodeEvent {

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeEventContainer.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeEventContainer.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.util.Objects;
 
 /**
- * @author Chamseddine Benhamed <Chamseddine.Benhamed at rte-france.com>
+ * @author Chamseddine Benhamed {@literal <Chamseddine.Benhamed at rte-france.com>}
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.MINIMAL_CLASS, include = JsonTypeInfo.As.PROPERTY)
 public class NodeEventContainer {

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeEventList.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeEventList.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodeEventList {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeMetadataUpdated.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeMetadataUpdated.java
@@ -13,7 +13,7 @@ import com.powsybl.afs.storage.NodeGenericMetadata;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodeMetadataUpdated extends NodeEvent {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeNameUpdated.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeNameUpdated.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 
 /**
  *
- * @author Nassirou Nambiena <nassirou.nambiena at rte-france.com>
+ * @author Nassirou Nambiena {@literal <nassirou.nambiena at rte-france.com>}
  */
 public class NodeNameUpdated extends NodeEvent {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeRemoved.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/NodeRemoved.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodeRemoved extends NodeEvent {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/ParentChanged.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/ParentChanged.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class ParentChanged extends NodeEvent {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/TimeSeriesCleared.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/TimeSeriesCleared.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class TimeSeriesCleared extends NodeEvent {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/TimeSeriesCreated.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/TimeSeriesCreated.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class TimeSeriesCreated extends NodeEvent {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/TimeSeriesDataUpdated.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/events/TimeSeriesDataUpdated.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class TimeSeriesDataUpdated extends NodeEvent {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/json/AppStorageJsonModule.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/json/AppStorageJsonModule.java
@@ -12,7 +12,7 @@ import com.powsybl.afs.storage.NodeInfo;
 import com.powsybl.timeseries.json.TimeSeriesJsonModule;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AppStorageJsonModule extends TimeSeriesJsonModule {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/json/NodeDependencyDeserializer.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/json/NodeDependencyDeserializer.java
@@ -16,7 +16,7 @@ import com.powsybl.afs.storage.NodeInfo;
 import java.io.IOException;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodeDependencyDeserializer extends StdDeserializer<NodeDependency> {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/json/NodeDependencySerializer.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/json/NodeDependencySerializer.java
@@ -14,7 +14,7 @@ import com.powsybl.afs.storage.NodeDependency;
 import java.io.IOException;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodeDependencySerializer extends StdSerializer<NodeDependency> {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/json/NodeGenericMetadataJsonDeserializer.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/json/NodeGenericMetadataJsonDeserializer.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodeGenericMetadataJsonDeserializer extends StdDeserializer<NodeGenericMetadata> {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/json/NodeGenericMetadataJsonSerializer.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/json/NodeGenericMetadataJsonSerializer.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 import java.util.Map;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodeGenericMetadataJsonSerializer extends StdSerializer<NodeGenericMetadata> {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/json/NodeInfoJsonDeserializer.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/json/NodeInfoJsonDeserializer.java
@@ -16,7 +16,7 @@ import com.powsybl.afs.storage.NodeInfo;
 import java.io.IOException;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodeInfoJsonDeserializer extends StdDeserializer<NodeInfo> {
 

--- a/afs-storage-api/src/main/java/com/powsybl/afs/storage/json/NodeInfoJsonSerializer.java
+++ b/afs-storage-api/src/main/java/com/powsybl/afs/storage/json/NodeInfoJsonSerializer.java
@@ -14,7 +14,7 @@ import com.powsybl.afs.storage.NodeInfo;
 import java.io.IOException;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodeInfoJsonSerializer extends StdSerializer<NodeInfo> {
 

--- a/afs-storage-api/src/test/java/com/powsybl/afs/storage/AbstractAppStorageArchiveTest.java
+++ b/afs-storage-api/src/test/java/com/powsybl/afs/storage/AbstractAppStorageArchiveTest.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import static org.junit.Assert.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractAppStorageArchiveTest {
 

--- a/afs-storage-api/src/test/java/com/powsybl/afs/storage/AbstractAppStorageTest.java
+++ b/afs-storage-api/src/test/java/com/powsybl/afs/storage/AbstractAppStorageTest.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public abstract class AbstractAppStorageTest {
 

--- a/afs-storage-api/src/test/java/com/powsybl/afs/storage/AppStorageDataSourceTest.java
+++ b/afs-storage-api/src/test/java/com/powsybl/afs/storage/AppStorageDataSourceTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class AppStorageDataSourceTest {
 

--- a/afs-storage-api/src/test/java/com/powsybl/afs/storage/NodeDependencyTest.java
+++ b/afs-storage-api/src/test/java/com/powsybl/afs/storage/NodeDependencyTest.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 import static org.junit.Assert.assertEquals;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodeDependencyTest {
 

--- a/afs-storage-api/src/test/java/com/powsybl/afs/storage/NodeGenericMetadataTest.java
+++ b/afs-storage-api/src/test/java/com/powsybl/afs/storage/NodeGenericMetadataTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodeGenericMetadataTest {
 

--- a/afs-storage-api/src/test/java/com/powsybl/afs/storage/NodeInfoTest.java
+++ b/afs-storage-api/src/test/java/com/powsybl/afs/storage/NodeInfoTest.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 import static org.junit.Assert.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodeInfoTest {
 

--- a/afs-storage-api/src/test/java/com/powsybl/afs/storage/UtilsTest.java
+++ b/afs-storage-api/src/test/java/com/powsybl/afs/storage/UtilsTest.java
@@ -18,7 +18,7 @@ import java.nio.file.Path;
 import static org.junit.Assert.*;
 
 /**
- * @author Valentin Berthault <valentin.berthault at rte-france.com>
+ * @author Valentin Berthault {@literal <valentin.berthault at rte-france.com>}
  */
 
 public class UtilsTest {

--- a/afs-storage-api/src/test/java/com/powsybl/afs/storage/buffer/StorageChangeBufferTest.java
+++ b/afs-storage-api/src/test/java/com/powsybl/afs/storage/buffer/StorageChangeBufferTest.java
@@ -17,7 +17,7 @@ import java.util.Collections;
 import static org.junit.Assert.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class StorageChangeBufferTest {
 

--- a/afs-storage-api/src/test/java/com/powsybl/afs/storage/buffer/StorageChangeTest.java
+++ b/afs-storage-api/src/test/java/com/powsybl/afs/storage/buffer/StorageChangeTest.java
@@ -19,7 +19,7 @@ import java.util.Collections;
 import static org.junit.Assert.assertEquals;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class StorageChangeTest {
 

--- a/afs-storage-api/src/test/java/com/powsybl/afs/storage/events/NodeEventContainerTest.java
+++ b/afs-storage-api/src/test/java/com/powsybl/afs/storage/events/NodeEventContainerTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 /**
- * @author Chamseddine Benhamed <Chamseddine.Benhamed at rte-france.com>
+ * @author Chamseddine Benhamed {@literal <Chamseddine.Benhamed at rte-france.com>}
  */
 public class NodeEventContainerTest {
 

--- a/afs-storage-api/src/test/java/com/powsybl/afs/storage/events/NodeEventTest.java
+++ b/afs-storage-api/src/test/java/com/powsybl/afs/storage/events/NodeEventTest.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 import static org.junit.Assert.assertEquals;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodeEventTest {
 

--- a/afs-ws/afs-ws-client-utils/src/main/java/com/powsybl/afs/ws/client/utils/ClientUtils.java
+++ b/afs-ws/afs-ws-client-utils/src/main/java/com/powsybl/afs/ws/client/utils/ClientUtils.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class ClientUtils {
 

--- a/afs-ws/afs-ws-client-utils/src/main/java/com/powsybl/afs/ws/client/utils/RemoteServiceConfig.java
+++ b/afs-ws/afs-ws-client-utils/src/main/java/com/powsybl/afs/ws/client/utils/RemoteServiceConfig.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class RemoteServiceConfig {
 

--- a/afs-ws/afs-ws-client-utils/src/main/java/com/powsybl/afs/ws/client/utils/UncheckedDeploymentException.java
+++ b/afs-ws/afs-ws-client-utils/src/main/java/com/powsybl/afs/ws/client/utils/UncheckedDeploymentException.java
@@ -9,7 +9,7 @@ package com.powsybl.afs.ws.client.utils;
 import javax.websocket.DeploymentException;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class UncheckedDeploymentException extends RuntimeException {
 

--- a/afs-ws/afs-ws-client-utils/src/main/java/com/powsybl/afs/ws/client/utils/UserSession.java
+++ b/afs-ws/afs-ws-client-utils/src/main/java/com/powsybl/afs/ws/client/utils/UserSession.java
@@ -11,7 +11,7 @@ import com.powsybl.commons.net.UserProfile;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class UserSession {
 

--- a/afs-ws/afs-ws-client-utils/src/test/java/com/powsybl/afs/ws/client/utils/CodeCoverageTest.java
+++ b/afs-ws/afs-ws-client-utils/src/test/java/com/powsybl/afs/ws/client/utils/CodeCoverageTest.java
@@ -9,7 +9,7 @@ package com.powsybl.afs.ws.client.utils;
 import org.junit.Test;
 
 /**
- * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ * @author Mathieu Bague {@literal <mathieu.bague at rte-france.com>}
  */
 public class CodeCoverageTest {
 

--- a/afs-ws/afs-ws-client-utils/src/test/java/com/powsybl/afs/ws/client/utils/RemoteServiceConfigTest.java
+++ b/afs-ws/afs-ws-client-utils/src/test/java/com/powsybl/afs/ws/client/utils/RemoteServiceConfigTest.java
@@ -20,7 +20,7 @@ import java.nio.file.FileSystem;
 import static org.junit.Assert.*;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class RemoteServiceConfigTest {
 

--- a/afs-ws/afs-ws-client/src/main/java/com/powsybl/afs/ws/client/RemoteAppFileSystemProvider.java
+++ b/afs-ws/afs-ws-client/src/main/java/com/powsybl/afs/ws/client/RemoteAppFileSystemProvider.java
@@ -27,8 +27,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
- * @author Ali Tahanout <ali.tahanout at rte-france.com>
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Ali Tahanout {@literal <ali.tahanout at rte-france.com>}
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @AutoService(AppFileSystemProvider.class)
 public class RemoteAppFileSystemProvider implements AppFileSystemProvider {

--- a/afs-ws/afs-ws-client/src/test/java/com/powsybl/afs/ws/client/CodeCoverageTest.java
+++ b/afs-ws/afs-ws-client/src/test/java/com/powsybl/afs/ws/client/CodeCoverageTest.java
@@ -9,7 +9,7 @@ package com.powsybl.afs.ws.client;
 import org.junit.Test;
 
 /**
- * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ * @author Mathieu Bague {@literal <mathieu.bague at rte-france.com>}
  */
 public class CodeCoverageTest {
 

--- a/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/AfsSimpleSecurityContext.java
+++ b/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/AfsSimpleSecurityContext.java
@@ -14,7 +14,7 @@ import java.security.Principal;
 import java.util.Objects;
 
 /**
- * @author Paul Bui-Quang <paul.buiquang at rte-france.com>
+ * @author Paul Bui-Quang {@literal <paul.buiquang at rte-france.com>}
  */
 public class AfsSimpleSecurityContext implements SecurityContext {
 

--- a/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/AppDataBean.java
+++ b/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/AppDataBean.java
@@ -23,7 +23,7 @@ import javax.ws.rs.core.Response;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @Named
 @Singleton

--- a/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/JwtTokenNeeded.java
+++ b/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/JwtTokenNeeded.java
@@ -15,7 +15,7 @@ import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * @author Ali Tahanout <ali.tahanout at rte-france.com>
+ * @author Ali Tahanout {@literal <ali.tahanout at rte-france.com>}
  */
 @NameBinding
 @Retention(RUNTIME)

--- a/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/JwtTokenNeededFilter.java
+++ b/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/JwtTokenNeededFilter.java
@@ -25,7 +25,7 @@ import javax.ws.rs.ext.Provider;
 import java.security.Key;
 
 /**
- * @author Ali Tahanout <ali.tahanout at rte-france.com>
+ * @author Ali Tahanout {@literal <ali.tahanout at rte-france.com>}
  */
 @Provider
 @JwtTokenNeeded

--- a/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/KeyGenerator.java
+++ b/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/KeyGenerator.java
@@ -9,7 +9,7 @@ package com.powsybl.afs.ws.server.utils;
 import java.security.Key;
 
 /**
- * @author Ali Tahanout <ali.tahanout at rte-france.com>
+ * @author Ali Tahanout {@literal <ali.tahanout at rte-france.com>}
  */
 public interface KeyGenerator {
 

--- a/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/SecurityConfig.java
+++ b/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/SecurityConfig.java
@@ -11,7 +11,7 @@ import com.powsybl.commons.config.PlatformConfig;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class SecurityConfig {
 

--- a/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/SimpleKeyGenerator.java
+++ b/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/SimpleKeyGenerator.java
@@ -10,7 +10,7 @@ import javax.crypto.spec.SecretKeySpec;
 import java.security.Key;
 
 /**
- * @author Ali Tahanout <ali.tahanout at rte-france.com>
+ * @author Ali Tahanout {@literal <ali.tahanout at rte-france.com>}
  */
 public class SimpleKeyGenerator implements KeyGenerator {
 

--- a/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/SwaggerConfigExtension.java
+++ b/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/SwaggerConfigExtension.java
@@ -16,7 +16,7 @@ import java.util.function.Supplier;
  * Swagger BeanConfig supplier.
  * Only one extension can be defined per application.
  * The first extension found will be used.
- * @author Paul Bui-Quang <paul.buiquang at rte-france.com>
+ * @author Paul Bui-Quang {@literal <paul.buiquang at rte-france.com>}
  */
 public interface SwaggerConfigExtension extends Supplier<OpenAPI> {
 

--- a/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/ThrowableExceptionMapper.java
+++ b/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/ThrowableExceptionMapper.java
@@ -17,7 +17,7 @@ import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @Provider
 public class ThrowableExceptionMapper implements ExceptionMapper<Throwable> {

--- a/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/UserAuthenticator.java
+++ b/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/UserAuthenticator.java
@@ -9,7 +9,7 @@ package com.powsybl.afs.ws.server.utils;
 import com.powsybl.commons.net.UserProfile;
 
 /**
- * @author Ali Tahanout <ali.tahanout at rte-france.com>
+ * @author Ali Tahanout {@literal <ali.tahanout at rte-france.com>}
  */
 public interface UserAuthenticator {
 

--- a/afs-ws/afs-ws-server-utils/src/test/java/com/powsybl/afs/ws/server/utils/AfsSimpleSecurityContextTest.java
+++ b/afs-ws/afs-ws-server-utils/src/test/java/com/powsybl/afs/ws/server/utils/AfsSimpleSecurityContextTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * @author Paul Bui-Quang <paul.buiquang at rte-france.com>
+ * @author Paul Bui-Quang {@literal <paul.buiquang at rte-france.com>}
  */
 public class AfsSimpleSecurityContextTest {
 

--- a/afs-ws/afs-ws-server/src/main/java/com/powsybl/afs/ws/server/AppStorageApplication.java
+++ b/afs-ws/afs-ws-server/src/main/java/com/powsybl/afs/ws/server/AppStorageApplication.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.ServiceLoader;
 
 /**
- * @author Ali Tahanout <ali.tahanout at rte-france.com>
+ * @author Ali Tahanout {@literal <ali.tahanout at rte-france.com>}
  */
 @ApplicationPath("/rest")
 public class AppStorageApplication extends Application {

--- a/afs-ws/afs-ws-server/src/main/java/com/powsybl/afs/ws/server/AppStorageServer.java
+++ b/afs-ws/afs-ws-server/src/main/java/com/powsybl/afs/ws/server/AppStorageServer.java
@@ -47,8 +47,8 @@ import java.time.Instant;
 import java.util.*;
 
 /**
- * @author Ali Tahanout <ali.tahanout at rte-france.com>
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Ali Tahanout {@literal <ali.tahanout at rte-france.com>}
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @Named
 @ApplicationScoped

--- a/afs-ws/afs-ws-server/src/main/java/com/powsybl/afs/ws/server/NodeEventContainerDecoder.java
+++ b/afs-ws/afs-ws-server/src/main/java/com/powsybl/afs/ws/server/NodeEventContainerDecoder.java
@@ -10,7 +10,7 @@ import com.powsybl.afs.storage.events.NodeEventContainer;
 import com.powsybl.afs.ws.utils.JacksonDecoder;
 
 /**
- * @author Chamseddine Benhamed <Chamseddine.Benhamed at rte-france.com>
+ * @author Chamseddine Benhamed {@literal <Chamseddine.Benhamed at rte-france.com>}
  */
 public class NodeEventContainerDecoder extends JacksonDecoder<NodeEventContainer> {
 

--- a/afs-ws/afs-ws-server/src/main/java/com/powsybl/afs/ws/server/NodeEventListEncoder.java
+++ b/afs-ws/afs-ws-server/src/main/java/com/powsybl/afs/ws/server/NodeEventListEncoder.java
@@ -10,7 +10,7 @@ import com.powsybl.afs.storage.events.NodeEventList;
 import com.powsybl.afs.ws.utils.JacksonEncoder;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodeEventListEncoder extends JacksonEncoder<NodeEventList> {
 }

--- a/afs-ws/afs-ws-server/src/main/java/com/powsybl/afs/ws/server/NodeEventServer.java
+++ b/afs-ws/afs-ws-server/src/main/java/com/powsybl/afs/ws/server/NodeEventServer.java
@@ -20,7 +20,7 @@ import javax.websocket.server.PathParam;
 import javax.websocket.server.ServerEndpoint;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @ServerEndpoint(value = "/messages/" + AfsRestApi.RESOURCE_ROOT + "/" + AfsRestApi.VERSION + "/node_events/{fileSystemName}",
                 encoders = {NodeEventListEncoder.class}, decoders = {NodeEventContainerDecoder.class})

--- a/afs-ws/afs-ws-server/src/main/java/com/powsybl/afs/ws/server/TaskEventServer.java
+++ b/afs-ws/afs-ws-server/src/main/java/com/powsybl/afs/ws/server/TaskEventServer.java
@@ -20,7 +20,7 @@ import javax.websocket.server.PathParam;
 import javax.websocket.server.ServerEndpoint;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @ServerEndpoint(value = "/messages/" + AfsRestApi.RESOURCE_ROOT + "/" + AfsRestApi.VERSION + "/task_events/{fileSystemName}/{projectId}",
                 encoders = {NodeEventListEncoder.class})

--- a/afs-ws/afs-ws-server/src/main/java/com/powsybl/afs/ws/server/UserEndpoint.java
+++ b/afs-ws/afs-ws-server/src/main/java/com/powsybl/afs/ws/server/UserEndpoint.java
@@ -30,7 +30,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 
 /**
- * @author Ali Tahanout <ali.tahanout at rte-france.com>
+ * @author Ali Tahanout {@literal <ali.tahanout at rte-france.com>}
  */
 @Path("/users")
 public class UserEndpoint {

--- a/afs-ws/afs-ws-server/src/main/java/com/powsybl/afs/ws/server/WebSocketContext.java
+++ b/afs-ws/afs-ws-server/src/main/java/com/powsybl/afs/ws/server/WebSocketContext.java
@@ -18,7 +18,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @Singleton
 public class WebSocketContext {

--- a/afs-ws/afs-ws-server/src/test/java/com/powsybl/afs/ws/server/AppDataBeanMock.java
+++ b/afs-ws/afs-ws-server/src/test/java/com/powsybl/afs/ws/server/AppDataBeanMock.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import static org.mockito.ArgumentMatchers.any;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @Specializes
 @Singleton

--- a/afs-ws/afs-ws-server/src/test/java/com/powsybl/afs/ws/server/AppStorageServerTest.java
+++ b/afs-ws/afs-ws-server/src/test/java/com/powsybl/afs/ws/server/AppStorageServerTest.java
@@ -44,8 +44,8 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
 
 /**
- * @author Ali Tahanout <ali.tahanout at rte-france.com>
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Ali Tahanout {@literal <ali.tahanout at rte-france.com>}
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @RunWith(Arquillian.class)
 @RunAsClient

--- a/afs-ws/afs-ws-server/src/test/java/com/powsybl/afs/ws/server/DummyApplication.java
+++ b/afs-ws/afs-ws-server/src/test/java/com/powsybl/afs/ws/server/DummyApplication.java
@@ -11,7 +11,7 @@ package com.powsybl.afs.ws.server;
 import javax.ws.rs.ApplicationPath;
 
 /**
- * @author Paul Bui-Quang <paul.buiquang at rte-france.com>
+ * @author Paul Bui-Quang {@literal <paul.buiquang at rte-france.com>}
  */
 @ApplicationPath("/rest")
 public class DummyApplication {

--- a/afs-ws/afs-ws-server/src/test/java/com/powsybl/afs/ws/server/DummyEndpoint.java
+++ b/afs-ws/afs-ws-server/src/test/java/com/powsybl/afs/ws/server/DummyEndpoint.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.util.concurrent.CancellationException;
 
 /**
- * @author Paul Bui-Quang <paul.buiquang at rte-france.com>
+ * @author Paul Bui-Quang {@literal <paul.buiquang at rte-france.com>}
  */
 @Named
 @ApplicationScoped

--- a/afs-ws/afs-ws-server/src/test/java/com/powsybl/afs/ws/server/SwaggerExtensionTest.java
+++ b/afs-ws/afs-ws-server/src/test/java/com/powsybl/afs/ws/server/SwaggerExtensionTest.java
@@ -19,7 +19,7 @@ import java.util.List;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 /**
- * @author Paul Bui-Quang <paul.buiquang at rte-france.com>
+ * @author Paul Bui-Quang {@literal <paul.buiquang at rte-france.com>}
  */
 public class SwaggerExtensionTest {
 

--- a/afs-ws/afs-ws-server/src/test/java/com/powsybl/afs/ws/server/UserAuthenticatorMock.java
+++ b/afs-ws/afs-ws-server/src/test/java/com/powsybl/afs/ws/server/UserAuthenticatorMock.java
@@ -12,7 +12,7 @@ import com.powsybl.commons.net.UserProfile;
 import javax.inject.Named;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @Named
 public class UserAuthenticatorMock implements UserAuthenticator {

--- a/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/NodeEventClient.java
+++ b/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/NodeEventClient.java
@@ -21,7 +21,7 @@ import java.io.UncheckedIOException;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @ClientEndpoint(decoders = {NodeEventListDecoder.class}, encoders = {NodeEventContainerEncoder.class})
 public class NodeEventClient implements AutoCloseable {

--- a/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/NodeEventContainerEncoder.java
+++ b/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/NodeEventContainerEncoder.java
@@ -10,7 +10,7 @@ import com.powsybl.afs.storage.events.NodeEventContainer;
 import com.powsybl.afs.ws.utils.JacksonEncoder;
 
 /**
- * @author Chamseddine Benhamed <Chamseddine.Benhamed at rte-france.com>
+ * @author Chamseddine Benhamed {@literal <Chamseddine.Benhamed at rte-france.com>}
  */
 public class NodeEventContainerEncoder extends JacksonEncoder<NodeEventContainer> {
 }

--- a/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/NodeEventListDecoder.java
+++ b/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/NodeEventListDecoder.java
@@ -10,7 +10,7 @@ import com.powsybl.afs.storage.events.NodeEventList;
 import com.powsybl.afs.ws.utils.JacksonDecoder;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class NodeEventListDecoder extends JacksonDecoder<NodeEventList> {
 

--- a/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/RemoteAppStorage.java
+++ b/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/RemoteAppStorage.java
@@ -43,8 +43,8 @@ import java.util.concurrent.Future;
 import static com.powsybl.afs.ws.client.utils.ClientUtils.*;
 
 /**
- * @author Ali Tahanout <ali.tahanout at rte-france.com>
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Ali Tahanout {@literal <ali.tahanout at rte-france.com>}
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class RemoteAppStorage extends AbstractAppStorage {
 

--- a/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/RemoteTaskMonitor.java
+++ b/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/RemoteTaskMonitor.java
@@ -41,7 +41,7 @@ import static com.powsybl.afs.ws.client.utils.ClientUtils.readEntityIfOk;
 import static com.powsybl.afs.ws.storage.RemoteAppStorage.getWebTarget;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class RemoteTaskMonitor implements TaskMonitor {
 

--- a/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/SocketsUtils.java
+++ b/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/SocketsUtils.java
@@ -12,7 +12,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 /**
- * @author Chamseddine Benhamed <chamseddine.benhamed at rte-france.com>
+ * @author Chamseddine Benhamed {@literal <chamseddine.benhamed at rte-france.com>}
  */
 public final class SocketsUtils {
 

--- a/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/TaskEventClient.java
+++ b/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/TaskEventClient.java
@@ -15,7 +15,7 @@ import javax.websocket.*;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 @ClientEndpoint(decoders = {TaskEventDecoder.class})
 public class TaskEventClient {

--- a/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/TaskEventDecoder.java
+++ b/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/TaskEventDecoder.java
@@ -10,7 +10,7 @@ import com.powsybl.afs.TaskEvent;
 import com.powsybl.afs.ws.utils.JacksonDecoder;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class TaskEventDecoder extends JacksonDecoder<TaskEvent> {
 

--- a/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/WebSocketEventsBus.java
+++ b/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/WebSocketEventsBus.java
@@ -18,7 +18,7 @@ import java.net.URI;
 import java.util.Objects;
 
 /**
- * @author Chamseddine Benhamed <chamseddine.benhamed at rte-france.com>
+ * @author Chamseddine Benhamed {@literal <chamseddine.benhamed at rte-france.com>}
  */
 public class WebSocketEventsBus implements EventsBus {
 

--- a/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/websocket/AutoReconnectionConnectionManager.java
+++ b/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/websocket/AutoReconnectionConnectionManager.java
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * A connection manager which will attempt to reconnect at fixed time intervals.
  *
- * @author Sylvain Leclerc <sylvain.leclerc@rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc@rte-france.com>}
  */
 public class AutoReconnectionConnectionManager extends StandardConnectionManager {
 

--- a/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/websocket/StandardConnectionManager.java
+++ b/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/websocket/StandardConnectionManager.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 /**
  * A simple connection manager which does not try to reconnect on close.
  *
- * @author Sylvain Leclerc <sylvain.leclerc@rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc@rte-france.com>}
  */
 public class StandardConnectionManager implements WebsocketConnectionManager {
 

--- a/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/websocket/WebsocketConnectionManager.java
+++ b/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/websocket/WebsocketConnectionManager.java
@@ -11,7 +11,7 @@ import javax.websocket.Session;
 /**
  * Responsible for managing the connection to a websocket server endpoint.
  *
- * @author Sylvain Leclerc <sylvain.leclerc@rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc@rte-france.com>}
  */
 public interface WebsocketConnectionManager extends AutoCloseable {
 

--- a/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/websocket/WebsocketConnectionPolicy.java
+++ b/afs-ws/afs-ws-storage/src/main/java/com/powsybl/afs/ws/storage/websocket/WebsocketConnectionPolicy.java
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>The actual connection logic is implemented in {@link WebsocketConnectionManager} instances.
  *
- * @author Sylvain Leclerc <sylvain.leclerc@rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc@rte-france.com>}
  */
 public interface WebsocketConnectionPolicy {
 

--- a/afs-ws/afs-ws-storage/src/test/java/com/powsybl/afs/ws/storage/NodeEventClientReconnectionTest.java
+++ b/afs-ws/afs-ws-storage/src/test/java/com/powsybl/afs/ws/storage/NodeEventClientReconnectionTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * @author Sylvain Leclerc <sylvain.leclerc@rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc@rte-france.com>}
  */
 public class NodeEventClientReconnectionTest {
 

--- a/afs-ws/afs-ws-storage/src/test/java/com/powsybl/afs/ws/storage/websocket/WebsocketConnectionPolicyTest.java
+++ b/afs-ws/afs-ws-storage/src/test/java/com/powsybl/afs/ws/storage/websocket/WebsocketConnectionPolicyTest.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.*;
 
 /**
  *
- * @author Sylvain Leclerc <sylvain.leclerc@rte-france.com>
+ * @author Sylvain Leclerc {@literal <sylvain.leclerc@rte-france.com>}
  */
 public class WebsocketConnectionPolicyTest {
 

--- a/afs-ws/afs-ws-utils/src/main/java/com/powsybl/afs/ws/utils/AfsRestApi.java
+++ b/afs-ws/afs-ws-utils/src/main/java/com/powsybl/afs/ws/utils/AfsRestApi.java
@@ -7,7 +7,7 @@
 package com.powsybl.afs.ws.utils;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public final class AfsRestApi {
 

--- a/afs-ws/afs-ws-utils/src/main/java/com/powsybl/afs/ws/utils/ExceptionDetail.java
+++ b/afs-ws/afs-ws-utils/src/main/java/com/powsybl/afs/ws/utils/ExceptionDetail.java
@@ -11,7 +11,7 @@ package com.powsybl.afs.ws.utils;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * @author Paul Bui-Quang <paul.buiquang at rte-france.com>
+ * @author Paul Bui-Quang {@literal <paul.buiquang at rte-france.com>}
  */
 public class ExceptionDetail {
 

--- a/afs-ws/afs-ws-utils/src/main/java/com/powsybl/afs/ws/utils/JacksonDecoder.java
+++ b/afs-ws/afs-ws-utils/src/main/java/com/powsybl/afs/ws/utils/JacksonDecoder.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class JacksonDecoder<T> implements Decoder.Text<T> {
 

--- a/afs-ws/afs-ws-utils/src/main/java/com/powsybl/afs/ws/utils/JacksonEncoder.java
+++ b/afs-ws/afs-ws-utils/src/main/java/com/powsybl/afs/ws/utils/JacksonEncoder.java
@@ -15,7 +15,7 @@ import javax.websocket.Encoder;
 import javax.websocket.EndpointConfig;
 
 /**
- * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
  */
 public class JacksonEncoder<T> implements Encoder.Text<T> {
 

--- a/afs-ws/afs-ws-utils/src/main/java/com/powsybl/afs/ws/utils/JsonProvider.java
+++ b/afs-ws/afs-ws-utils/src/main/java/com/powsybl/afs/ws/utils/JsonProvider.java
@@ -16,7 +16,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.ext.Provider;
 
 /**
- * @author Ali Tahanout <ali.tahanout at rte-france.com>
+ * @author Ali Tahanout {@literal <ali.tahanout at rte-france.com>}
  */
 @Provider
 @Consumes({MediaType.APPLICATION_JSON})

--- a/afs-ws/afs-ws-utils/src/main/java/com/powsybl/afs/ws/utils/gzip/Compress.java
+++ b/afs-ws/afs-ws-utils/src/main/java/com/powsybl/afs/ws/utils/gzip/Compress.java
@@ -11,7 +11,7 @@ import javax.ws.rs.NameBinding;
 import java.lang.annotation.RetentionPolicy;
 
 /**
- * @author Ali Tahanout <ali.tahanout at rte-france.com>
+ * @author Ali Tahanout {@literal <ali.tahanout at rte-france.com>}
  */
 @NameBinding
 @Retention(RetentionPolicy.RUNTIME)

--- a/afs-ws/afs-ws-utils/src/main/java/com/powsybl/afs/ws/utils/gzip/ReaderInterceptorGzip.java
+++ b/afs-ws/afs-ws-utils/src/main/java/com/powsybl/afs/ws/utils/gzip/ReaderInterceptorGzip.java
@@ -19,7 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * @author Ali Tahanout <ali.tahanout at rte-france.com>
+ * @author Ali Tahanout {@literal <ali.tahanout at rte-france.com>}
  */
 @Provider
 public class ReaderInterceptorGzip implements ReaderInterceptor {

--- a/afs-ws/afs-ws-utils/src/main/java/com/powsybl/afs/ws/utils/gzip/WriterInterceptorGzip.java
+++ b/afs-ws/afs-ws-utils/src/main/java/com/powsybl/afs/ws/utils/gzip/WriterInterceptorGzip.java
@@ -9,7 +9,7 @@ package com.powsybl.afs.ws.utils.gzip;
 import javax.ws.rs.ext.Provider;
 
 /**
- * @author Ali Tahanout <ali.tahanout at rte-france.com>
+ * @author Ali Tahanout {@literal <ali.tahanout at rte-france.com>}
  */
 @Provider
 @Compress

--- a/afs-ws/afs-ws-utils/src/main/java/com/powsybl/afs/ws/utils/gzip/WriterInterceptorGzipCli.java
+++ b/afs-ws/afs-ws-utils/src/main/java/com/powsybl/afs/ws/utils/gzip/WriterInterceptorGzipCli.java
@@ -17,7 +17,7 @@ import java.io.OutputStream;
 import java.util.zip.GZIPOutputStream;
 
 /**
- * @author Ali Tahanout <ali.tahanout at rte-france.com>
+ * @author Ali Tahanout {@literal <ali.tahanout at rte-france.com>}
  */
 public class WriterInterceptorGzipCli implements WriterInterceptor {
 

--- a/afs-ws/afs-ws-utils/src/test/java/com/powsybl/afs/ws/utils/CodeCoverageTest.java
+++ b/afs-ws/afs-ws-utils/src/test/java/com/powsybl/afs/ws/utils/CodeCoverageTest.java
@@ -9,7 +9,7 @@ package com.powsybl.afs.ws.utils;
 import org.junit.Test;
 
 /**
- * @author Mathieu Bague <mathieu.bague at rte-france.com>
+ * @author Mathieu Bague {@literal <mathieu.bague at rte-france.com>}
  */
 public class CodeCoverageTest {
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No, but similar to https://github.com/powsybl/powsybl-core/pull/2753


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix for javadoc generation


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Errors related to the author's email address formatting occur when generating the javadoc.
Email addresses were written as `@author Name Surname <email>`


**What is the new behavior (if this is a feature change)?**
No more errors related to that when generating the javadoc.
Email addresses are written as `@author Name Surname {@literal <email> }`


