### PR TITLE
Kotlin downgrade to 1.9.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
         <jakartawsrs.version>3.1.0</jakartawsrs.version>
         <jimfs.version>1.3.0</jimfs.version>
         <jjwt.version>0.12.3</jjwt.version>
+        <kotlin.version>1.9.22</kotlin.version>
         <junit-jupiter.version>5.10.1</junit-jupiter.version>
         <mapdb.version>3.1.0</mapdb.version>
         <maven.core.version>3.9.5</maven.core.version>
@@ -301,6 +302,11 @@
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-client</artifactId>
                 <version>${resteasy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib</artifactId>
+                <version>${kotlin.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mapdb</groupId>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?**
In Mapdb pom.xml, the kotlin version is [1.9.22,1.9.99], which means that the last 1.9 version is downloaded, even if it is a snapshot version (which does not work on production environments).


**What is the new behavior (if this is a feature change)?**
Kotlin dependency is now added in powsybl-afs so that the version can be chosen (1.9.22 as of now).


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
