### PR TITLE
Delete AppDataBean ComputationManager fields to use those in AppData

### DIFF
--- a/afs-core/src/main/java/com/powsybl/afs/AppData.java
+++ b/afs-core/src/main/java/com/powsybl/afs/AppData.java
@@ -45,9 +45,9 @@ import java.util.stream.Collectors;
  */
 public class AppData implements AutoCloseable {
 
-    private final ComputationManager shortTimeExecutionComputationManager;
+    private ComputationManager shortTimeExecutionComputationManager;
 
-    private final ComputationManager longTimeExecutionComputationManager;
+    private ComputationManager longTimeExecutionComputationManager;
 
     private Map<String, AppFileSystem> fileSystems;
 
@@ -324,5 +324,13 @@ public class AppData implements AutoCloseable {
     @Override
     public void close() {
         closeFileSystems();
+    }
+
+    public void setShortTimeExecutionComputationManager(ComputationManager shortTimeExecutionComputationManager) {
+        this.shortTimeExecutionComputationManager = shortTimeExecutionComputationManager;
+    }
+
+    public void setLongTimeExecutionComputationManager(ComputationManager longTimeExecutionComputationManager) {
+        this.longTimeExecutionComputationManager = longTimeExecutionComputationManager;
     }
 }

--- a/afs-core/src/test/java/com/powsybl/afs/AppDataTest.java
+++ b/afs-core/src/test/java/com/powsybl/afs/AppDataTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 

--- a/afs-core/src/test/java/com/powsybl/afs/AppDataTest.java
+++ b/afs-core/src/test/java/com/powsybl/afs/AppDataTest.java
@@ -1,0 +1,48 @@
+package com.powsybl.afs;
+
+import com.powsybl.computation.ComputationManager;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+public class AppDataTest {
+    @Mock
+    private ComputationManager shortTimeExecutionComputationManager;
+    @Mock
+    private ComputationManager longTimeExecutionComputationManager;
+    private AppData appDataUnderTest;
+
+    @BeforeEach
+    void init() {
+        shortTimeExecutionComputationManager = mock(ComputationManager.class);
+        longTimeExecutionComputationManager = mock(ComputationManager.class);
+        appDataUnderTest = new AppData(shortTimeExecutionComputationManager, longTimeExecutionComputationManager);
+    }
+
+    @Test
+    void setLongTimeExecutionComputationManager() {
+        // GIVEN
+        appDataUnderTest.setLongTimeExecutionComputationManager(null);
+        Assertions.assertEquals(shortTimeExecutionComputationManager, appDataUnderTest.getLongTimeExecutionComputationManager());
+        // WHEN
+        appDataUnderTest.setLongTimeExecutionComputationManager(longTimeExecutionComputationManager);
+        // THEN
+        assertNotNull(appDataUnderTest.getLongTimeExecutionComputationManager());
+    }
+
+    @Test
+    void setShortTimeExecutionComputationManager() {
+        // GIVEN
+        appDataUnderTest.setShortTimeExecutionComputationManager(null);
+        Assertions.assertNull(appDataUnderTest.getShortTimeExecutionComputationManager());
+        // WHEN
+        appDataUnderTest.setShortTimeExecutionComputationManager(shortTimeExecutionComputationManager);
+        // THEN
+        assertNotNull(appDataUnderTest.getShortTimeExecutionComputationManager());
+    }
+}

--- a/afs-core/src/test/java/com/powsybl/afs/AppDataTest.java
+++ b/afs-core/src/test/java/com/powsybl/afs/AppDataTest.java
@@ -9,7 +9,7 @@ import org.mockito.Mock;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
-public class AppDataTest {
+class AppDataTest {
     @Mock
     private ComputationManager shortTimeExecutionComputationManager;
     @Mock

--- a/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/AppDataBean.java
+++ b/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/AppDataBean.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 public class AppDataBean {
     private static final Logger LOGGER = LoggerFactory.getLogger(AppDataBean.class);
 
-    protected AppData appData;
+    AppData appData;
 
     DefaultComputationManagerConfig config;
 
@@ -120,7 +120,7 @@ public class AppDataBean {
             }
         }
 
-        // Ne devrait pas être null, mais par sécurité
+        // Should never be null !
         if (config == null) {
             config = DefaultComputationManagerConfig.load();
         }

--- a/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/AppDataBean.java
+++ b/afs-ws/afs-ws-server-utils/src/main/java/com/powsybl/afs/ws/server/utils/AppDataBean.java
@@ -34,7 +34,7 @@ public class AppDataBean {
 
     AppData appData;
 
-    DefaultComputationManagerConfig config;
+    protected DefaultComputationManagerConfig config;
 
     public AppData getAppData() {
         return appData;

--- a/afs-ws/afs-ws-server-utils/src/test/java/com/powsybl/afs/ws/server/utils/AppDataBeanTest.java
+++ b/afs-ws/afs-ws-server-utils/src/test/java/com/powsybl/afs/ws/server/utils/AppDataBeanTest.java
@@ -1,13 +1,13 @@
 package com.powsybl.afs.ws.server.utils;
 
+import com.powsybl.afs.AppData;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.computation.*;
 import org.junit.jupiter.api.*;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.openMocks;
 
@@ -19,7 +19,9 @@ class AppDataBeanTest {
     private ComputationManager longTimeExecutionComputationManager;
     @Mock
     private DefaultComputationManagerConfig config;
-    @InjectMocks
+    @Mock
+    private AppData appData;
+
     private AppDataBean appDataBeanUnderTest;
 
     @BeforeEach
@@ -27,8 +29,10 @@ class AppDataBeanTest {
         appDataBeanUnderTest = new AppDataBean();
         shortTimeExecutionComputationManager = mock(ComputationManager.class);
         longTimeExecutionComputationManager = mock(ComputationManager.class);
+        appData = mock(AppData.class);
         config = mock(DefaultComputationManagerConfig.class);
         appDataBeanUnderTest.config = config;
+        appDataBeanUnderTest.appData = appData;
         openMocks(shortTimeExecutionComputationManager);
         openMocks(longTimeExecutionComputationManager);
     }
@@ -36,8 +40,10 @@ class AppDataBeanTest {
     @Test
     void reinitComputationManagerNominal() {
         // GIVEN
-        appDataBeanUnderTest.longTimeExecutionComputationManager = longTimeExecutionComputationManager;
-        appDataBeanUnderTest.shortTimeExecutionComputationManager = shortTimeExecutionComputationManager;
+        when(appData.getShortTimeExecutionComputationManager()).thenReturn(shortTimeExecutionComputationManager);
+        when(appData.getLongTimeExecutionComputationManager()).thenReturn(longTimeExecutionComputationManager);
+        when(config.createLongTimeExecutionComputationManager()).thenReturn(longTimeExecutionComputationManager);
+        when(config.createShortTimeExecutionComputationManager()).thenReturn(shortTimeExecutionComputationManager);
         // WHEN
         appDataBeanUnderTest.reinitComputationManager(false);
         // THEN
@@ -47,6 +53,8 @@ class AppDataBeanTest {
             com.powsybl.computation.ComputationManager ignored = verify(config, times(1)).createShortTimeExecutionComputationManager();
             com.powsybl.computation.ComputationManager ignored1 = verify(config, times(1)).createLongTimeExecutionComputationManager()
         ) {
+            verify(appData, times(1)).setLongTimeExecutionComputationManager(longTimeExecutionComputationManager);
+            verify(appData, times(1)).setShortTimeExecutionComputationManager(shortTimeExecutionComputationManager);
             verifyNoMoreInteractions(config);
         }
     }
@@ -54,8 +62,10 @@ class AppDataBeanTest {
     @Test
     void reinitComputationManagerManagerExceptionLogged() {
         // GIVEN
-        appDataBeanUnderTest.longTimeExecutionComputationManager = longTimeExecutionComputationManager;
-        appDataBeanUnderTest.shortTimeExecutionComputationManager = shortTimeExecutionComputationManager;
+        when(appData.getShortTimeExecutionComputationManager()).thenReturn(shortTimeExecutionComputationManager);
+        when(appData.getLongTimeExecutionComputationManager()).thenReturn(longTimeExecutionComputationManager);
+        when(config.createLongTimeExecutionComputationManager()).thenReturn(longTimeExecutionComputationManager);
+        when(config.createShortTimeExecutionComputationManager()).thenReturn(shortTimeExecutionComputationManager);
         doThrow(new Exception("SHORT")).when(shortTimeExecutionComputationManager).close();
         doThrow(new Exception("LONG")).when(longTimeExecutionComputationManager).close();
         // WHEN
@@ -74,8 +84,8 @@ class AppDataBeanTest {
     @Test
     void reinitComputationManagerManagerThrowsExceptionShortTime() {
         // GIVEN
-        appDataBeanUnderTest.longTimeExecutionComputationManager = longTimeExecutionComputationManager;
-        appDataBeanUnderTest.shortTimeExecutionComputationManager = shortTimeExecutionComputationManager;
+        when(appData.getShortTimeExecutionComputationManager()).thenReturn(shortTimeExecutionComputationManager);
+        when(appData.getLongTimeExecutionComputationManager()).thenReturn(longTimeExecutionComputationManager);
         doThrow(new Exception("SHORT")).when(shortTimeExecutionComputationManager).close();
         // WHEN
         PowsyblException exception = assertThrows(PowsyblException.class, () -> appDataBeanUnderTest.reinitComputationManager(true));
@@ -94,8 +104,8 @@ class AppDataBeanTest {
     @Test
     void reinitComputationManagerManagerThrowsExceptionLongTime() {
         // GIVEN
-        appDataBeanUnderTest.longTimeExecutionComputationManager = longTimeExecutionComputationManager;
-        appDataBeanUnderTest.shortTimeExecutionComputationManager = shortTimeExecutionComputationManager;
+        when(appData.getShortTimeExecutionComputationManager()).thenReturn(shortTimeExecutionComputationManager);
+        when(appData.getLongTimeExecutionComputationManager()).thenReturn(longTimeExecutionComputationManager);
         doThrow(new Exception("LONG")).when(longTimeExecutionComputationManager).close();
         // WHEN
         PowsyblException exception = assertThrows(PowsyblException.class, () -> appDataBeanUnderTest.reinitComputationManager(true));
@@ -114,8 +124,8 @@ class AppDataBeanTest {
     @Test
     void reinitComputationManagerManagerNull() {
         // GIVEN
-        appDataBeanUnderTest.longTimeExecutionComputationManager = null;
-        appDataBeanUnderTest.shortTimeExecutionComputationManager = null;
+        when(appData.getShortTimeExecutionComputationManager()).thenReturn(null);
+        when(appData.getLongTimeExecutionComputationManager()).thenReturn(null);
         // WHEN
         appDataBeanUnderTest.reinitComputationManager(false);
         // THEN
@@ -127,5 +137,60 @@ class AppDataBeanTest {
         ) {
             verifyNoMoreInteractions(config);
         }
+    }
+
+    @Test
+    void reinitComputationWithConfigNull() {
+        // GIVEN
+        when(appData.getShortTimeExecutionComputationManager()).thenReturn(null);
+        when(appData.getLongTimeExecutionComputationManager()).thenReturn(null);
+        appDataBeanUnderTest.config = null;
+        // WHEN
+        appDataBeanUnderTest.reinitComputationManager(false);
+        // THEN
+        verify(longTimeExecutionComputationManager, times(0)).close();
+        verify(shortTimeExecutionComputationManager, times(0)).close();
+        assertNotNull(appDataBeanUnderTest.config);
+        verifyNoMoreInteractions(config);
+    }
+
+    @Test
+    void reInit() {
+        // GIVEN
+        appDataBeanUnderTest.config = null;
+        appDataBeanUnderTest.appData = null;
+        // WHEN
+        appDataBeanUnderTest.init();
+        // THEN
+        assertNotNull(appDataBeanUnderTest.config);
+        assertNotNull(appDataBeanUnderTest.appData);
+    }
+
+    @Test
+    void cleanCase1() {
+        // GIVEN
+        when(appData.getShortTimeExecutionComputationManager()).thenReturn(shortTimeExecutionComputationManager);
+        when(appData.getLongTimeExecutionComputationManager()).thenReturn(longTimeExecutionComputationManager);
+        // WHEN
+        appDataBeanUnderTest.clean();
+        // THEN
+        verify(appData, times(1)).close();
+        verify(longTimeExecutionComputationManager, times(1)).close();
+        verify(shortTimeExecutionComputationManager, times(1)).close();
+        verifyNoMoreInteractions(config);
+    }
+
+    @Test
+    void cleanCase2() {
+        // GIVEN
+        when(appData.getShortTimeExecutionComputationManager()).thenReturn(shortTimeExecutionComputationManager);
+        when(appData.getLongTimeExecutionComputationManager()).thenReturn(null);
+        // WHEN
+        appDataBeanUnderTest.clean();
+        // THEN
+        verify(appData, times(1)).close();
+        verify(longTimeExecutionComputationManager, times(0)).close();
+        verify(shortTimeExecutionComputationManager, times(1)).close();
+        verifyNoMoreInteractions(config);
     }
 }

--- a/afs-ws/afs-ws-server-utils/src/test/java/com/powsybl/afs/ws/server/utils/AppDataBeanTest.java
+++ b/afs-ws/afs-ws-server-utils/src/test/java/com/powsybl/afs/ws/server/utils/AppDataBeanTest.java
@@ -4,7 +4,6 @@ import com.powsybl.afs.AppData;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.computation.*;
 import org.junit.jupiter.api.*;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
 import static org.junit.jupiter.api.Assertions.*;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Feature

**What is the current behavior?**
The only way to reinitialize the connection manager is to call clean() and init() but these methods also reinitialize other backend connections (Cassandra ...)

**What is the new behavior (if this is a feature change)?**
The existing clean() and init() methods are still there. A new method reinitComputationManager() is added to reinitialize the computation manager alone without impacting other backend 


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
