### PR TITLE
Fix logo redirection

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,7 +108,7 @@ html_favicon = "_static/favicon.ico"
 html_context = {
     "copyright_year": copyright_year,
     "github_repository": github_repository,
-    "sidebar_logo_href": "http://powsybl-core.readthedocs.io/"
+    "sidebar_logo_href": "https://powsybl.readthedocs.io/"
 }
 
 html_theme_options = {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**What kind of change does this PR introduce?**
Documentation update.


**What is the current behavior?**
The logo on readthedocs redirects to powsybl-core readthedocs page.


**What is the new behavior (if this is a feature change)?**
The logo on readthedocs redirects to powsybl main readthedocs page.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
