### PR TITLE
Send Slack notification only on failure or on demand

### DIFF
--- a/.github/workflows/snapshot-ci.yml
+++ b/.github/workflows/snapshot-ci.yml
@@ -180,7 +180,7 @@ jobs:
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": "*Workflow details:*\n\n${{ steps.format_results.outputs.formatted_results }}\n\nSee logs on <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|GitHub>"
+                      "text": "*Workflow details:*\n\n${{ steps.format_results.outputs.formatted_results }}\n\n@channel - See logs on <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|GitHub>"
                     }
                   }
                 ]
@@ -192,6 +192,7 @@ jobs:
 
       - name: Send Slack Notification
         uses: 8398a7/action-slack@28ba43ae48961b90635b50953d216767a6bea486 # v3.16.2
+        if: ${{ steps.workflow_status.outputs.status != 'Successful' || github.event_name == 'workflow_dispatch' }}
         with:
           author_name: 'powsybl-afs on GitHub'
           status: custom


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Feature

**What is the current behavior?**
Slack notification is sent on every CI launch

**What is the new behavior (if this is a feature change)?**
Slack notification in only sent if the CI fails or if it was activated manually

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
