### PR TITLE
Make VirtualCase static attributes public

### DIFF
--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/VirtualCase.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/VirtualCase.java
@@ -23,8 +23,8 @@ public class VirtualCase extends ProjectFile implements ProjectCase {
     public static final String PSEUDO_CLASS = "virtualCase";
     public static final int VERSION = 0;
 
-    static final String CASE_DEPENDENCY_NAME = "case";
-    static final String SCRIPT_DEPENDENCY_NAME = "script";
+    public static final String CASE_DEPENDENCY_NAME = "case";
+    public static final String SCRIPT_DEPENDENCY_NAME = "script";
 
     private final DependencyCache<ProjectFile> projectCaseDependency = new DependencyCache<>(this, CASE_DEPENDENCY_NAME, ProjectFile.class);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Feature

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [x] No

**What is the current behavior?**
<!-- You can also link to an open issue here -->
Some static attributes in VirtualCase are protected while they could be useful.


**What is the new behavior (if this is a feature change)?**
Those static attributes are now public


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
