### PR TITLE
Add pseudoClass customization for ModificationScriptBuilder and ActionScriptBuilder

### DIFF
--- a/afs-action-dsl/src/main/java/com/powsybl/afs/action/dsl/ActionScriptBuilder.java
+++ b/afs-action-dsl/src/main/java/com/powsybl/afs/action/dsl/ActionScriptBuilder.java
@@ -29,6 +29,8 @@ public class ActionScriptBuilder implements ProjectFileBuilder<ActionScript> {
 
     private String content;
 
+    private String pseudoClass = ActionScript.PSEUDO_CLASS;
+
     public ActionScriptBuilder(ProjectFileBuildContext context) {
         this.context = Objects.requireNonNull(context);
     }
@@ -40,6 +42,11 @@ public class ActionScriptBuilder implements ProjectFileBuilder<ActionScript> {
 
     public ActionScriptBuilder withContent(String content) {
         this.content = content;
+        return this;
+    }
+
+    public ActionScriptBuilder withPseudoClass(String pseudoClass) {
+        this.pseudoClass = pseudoClass;
         return this;
     }
 
@@ -58,7 +65,7 @@ public class ActionScriptBuilder implements ProjectFileBuilder<ActionScript> {
         }
 
         // create project file
-        NodeInfo info = context.getStorage().createNode(context.getFolderInfo().getId(), name, ActionScript.PSEUDO_CLASS, "", ActionScript.VERSION,
+        NodeInfo info = context.getStorage().createNode(context.getFolderInfo().getId(), name, pseudoClass, "", ActionScript.VERSION,
                 new NodeGenericMetadata());
 
         // store script

--- a/afs-action-dsl/src/test/java/com/powsybl/afs/action/dsl/ActionScriptTest.java
+++ b/afs-action-dsl/src/test/java/com/powsybl/afs/action/dsl/ActionScriptTest.java
@@ -13,6 +13,7 @@ import com.powsybl.afs.ProjectFileExtension;
 import com.powsybl.afs.mapdb.storage.MapDbAppStorage;
 import com.powsybl.afs.storage.AppStorage;
 import com.powsybl.afs.storage.InMemoryEventsBus;
+import com.powsybl.afs.storage.NodeInfo;
 import com.powsybl.contingency.Contingency;
 import com.powsybl.contingency.LineContingency;
 import com.powsybl.iidm.network.Line;
@@ -23,6 +24,8 @@ import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Geoffroy Jamgotchian {@literal <geoffroy.jamgotchian at rte-france.com>}
@@ -61,4 +64,52 @@ class ActionScriptTest extends AbstractProjectFileTest {
         Assertions.assertThat(contingencies).hasSameElementsAs(actionScript.getContingencies(network));
 
     }
+
+
+
+    @Test
+    void testActionScripCreationWithCustomPseudoClass() {
+        // Create a project in the root folder
+        Project project = afs.getRootFolder().createProject("project");
+
+        // Define a custom pseudo-class value
+        String customPseudoClass = "customPseudo";
+
+        // Build an ActionScript using the custom pseudo-class
+        project.getRootFolder().fileBuilder(ActionScriptBuilder.class)
+                .withName("customScript")
+                .withContent("script content")
+                .withPseudoClass(customPseudoClass)
+                .build();
+
+        // Retrieve the node info for the created script from storage
+        NodeInfo nodeInfo = storage
+                .getChildNode(project.getRootFolder().getId(), "customScript")
+                .orElseThrow(() -> new AssertionError("Node 'customScript' not found"));
+
+        // Assert that the pseudo-class of the node is set to the custom value
+        assertEquals(customPseudoClass, nodeInfo.getPseudoClass());
+    }
+
+    @Test
+    void testActionScripCreationWithDefaultPseudoClass() {
+        // Create a project in the root folder
+        Project project = afs.getRootFolder().createProject("project");
+
+        // Build an ActionScript without specifying a pseudo-class
+        project.getRootFolder().fileBuilder(ActionScriptBuilder.class)
+                .withName("defaultScript")
+                .withContent("script content")
+                .build();
+
+        // Retrieve the node info for the created script from storage
+        NodeInfo nodeInfo = storage
+                .getChildNode(project.getRootFolder().getId(), "defaultScript")
+                .orElseThrow(() -> new AssertionError("Node 'defaultScript' not found"));
+
+        // Assert that the pseudo-class of the node is set to the default value defined in ActionScript.PSEUDO_CLASS
+        assertEquals(ActionScript.PSEUDO_CLASS, nodeInfo.getPseudoClass());
+    }
+
+
 }

--- a/afs-action-dsl/src/test/java/com/powsybl/afs/action/dsl/ActionScriptTest.java
+++ b/afs-action-dsl/src/test/java/com/powsybl/afs/action/dsl/ActionScriptTest.java
@@ -65,8 +65,6 @@ class ActionScriptTest extends AbstractProjectFileTest {
 
     }
 
-
-
     @Test
     void testActionScripCreationWithCustomPseudoClass() {
         // Create a project in the root folder
@@ -110,6 +108,5 @@ class ActionScriptTest extends AbstractProjectFileTest {
         // Assert that the pseudo-class of the node is set to the default value defined in ActionScript.PSEUDO_CLASS
         assertEquals(ActionScript.PSEUDO_CLASS, nodeInfo.getPseudoClass());
     }
-
 
 }

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ModificationScriptBuilder.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/ModificationScriptBuilder.java
@@ -32,6 +32,8 @@ public class ModificationScriptBuilder implements ProjectFileBuilder<Modificatio
 
     private String content;
 
+    private String pseudoClass = ModificationScript.PSEUDO_CLASS;
+
     public ModificationScriptBuilder(ProjectFileBuildContext context) {
         this.context = Objects.requireNonNull(context);
     }
@@ -48,6 +50,11 @@ public class ModificationScriptBuilder implements ProjectFileBuilder<Modificatio
 
     public ModificationScriptBuilder withContent(String content) {
         this.content = content;
+        return this;
+    }
+
+    public ModificationScriptBuilder withPseudoClass(String pseudoClass) {
+        this.pseudoClass = pseudoClass;
         return this;
     }
 
@@ -69,7 +76,7 @@ public class ModificationScriptBuilder implements ProjectFileBuilder<Modificatio
         }
 
         // create project file
-        NodeInfo info = context.getStorage().createNode(context.getFolderInfo().getId(), name, ModificationScript.PSEUDO_CLASS, "", ModificationScript.VERSION,
+        NodeInfo info = context.getStorage().createNode(context.getFolderInfo().getId(), name, pseudoClass, "", ModificationScript.VERSION,
                 new NodeGenericMetadata().setString(ModificationScript.SCRIPT_TYPE, type.name()));
 
         // store script

--- a/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/ModificationScriptTest.java
+++ b/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/ModificationScriptTest.java
@@ -11,6 +11,7 @@ import com.powsybl.afs.*;
 import com.powsybl.afs.mapdb.storage.MapDbAppStorage;
 import com.powsybl.afs.storage.AppStorage;
 import com.powsybl.afs.storage.InMemoryEventsBus;
+import com.powsybl.afs.storage.NodeInfo;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -181,4 +182,51 @@ class ModificationScriptTest extends AbstractProjectFileTest {
         assertEquals("include_script11", include1.getName());
         assertEquals("include_script11", script.getIncludedScripts().get(1).getName());
     }
+
+    @Test
+    void testModificationScriptCreationWithCustomPseudoClass() {
+        // Create a project in the root folder
+        Project project = afs.getRootFolder().createProject("project");
+
+        // Define a custom pseudo-class value
+        String customPseudoClass = "customPseudo";
+
+        // Build a ModificationScript using the custom pseudo-class
+        ModificationScript modificationScript = project.getRootFolder().fileBuilder(ModificationScriptBuilder.class)
+                .withName("customScript")
+                .withType(ScriptType.GROOVY)
+                .withContent("println 'hello'")
+                .withPseudoClass(customPseudoClass)
+                .build();
+
+        // Retrieve the node info for the created script from storage
+        NodeInfo nodeInfo = storage.getChildNode(project.getRootFolder().getId(), "customScript")
+                .orElseThrow(() -> new AssertionError("Node 'customScript' not found"));
+
+        // Assert that the pseudo-class of the node is set to the custom value
+        assertEquals(customPseudoClass, nodeInfo.getPseudoClass());
+    }
+
+    @Test
+    void testModificationScriptCreationWithDefaultPseudoClass() {
+        // Create a project in the root folder
+        Project project = afs.getRootFolder().createProject("project");
+
+        // Build a ModificationScript without specifying a pseudo-class, so the default should be used
+        ModificationScript modificationScript = project.getRootFolder().fileBuilder(ModificationScriptBuilder.class)
+                .withName("defaultScript")
+                .withType(ScriptType.GROOVY)
+                .withContent("println 'hello'")
+                .build();
+
+        // Retrieve the node info for the created script from storage
+        NodeInfo nodeInfo = storage.getChildNode(project.getRootFolder().getId(), "defaultScript")
+                .orElseThrow(() -> new AssertionError("Node 'defaultScript' not found"));
+
+        // Assert that the pseudo-class of the node is set to the default value defined in ModificationScript.PSEUDO_CLASS
+        assertEquals(ModificationScript.PSEUDO_CLASS, nodeInfo.getPseudoClass());
+    }
+
+
+
 }

--- a/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/ModificationScriptTest.java
+++ b/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/ModificationScriptTest.java
@@ -195,7 +195,7 @@ class ModificationScriptTest extends AbstractProjectFileTest {
         ModificationScript modificationScript = project.getRootFolder().fileBuilder(ModificationScriptBuilder.class)
                 .withName("customScript")
                 .withType(ScriptType.GROOVY)
-                .withContent("println 'hello'")
+                .withContent("script content")
                 .withPseudoClass(customPseudoClass)
                 .build();
 
@@ -216,7 +216,7 @@ class ModificationScriptTest extends AbstractProjectFileTest {
         ModificationScript modificationScript = project.getRootFolder().fileBuilder(ModificationScriptBuilder.class)
                 .withName("defaultScript")
                 .withType(ScriptType.GROOVY)
-                .withContent("println 'hello'")
+                .withContent("script content")
                 .build();
 
         // Retrieve the node info for the created script from storage
@@ -226,7 +226,5 @@ class ModificationScriptTest extends AbstractProjectFileTest {
         // Assert that the pseudo-class of the node is set to the default value defined in ModificationScript.PSEUDO_CLASS
         assertEquals(ModificationScript.PSEUDO_CLASS, nodeInfo.getPseudoClass());
     }
-
-
 
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
Feature

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [x] No

**What is the current behavior?**
<!-- You can also link to an open issue here -->
Both `ActionScriptBuilder` and `ModificationScriptBuilder` create scripts using fixed pseudo-class values:
 * `ActionScriptBuilder` uses `ActionScript.PSEUDO_CLASS`: "actionScript"
 * `ModificationScriptBuilder` uses `ModificationScript.PSEUDO_CLASS`: "modificationScript"

**What is the new behavior (if this is a feature change)?**
The builders now allow customization of the pseudo-class through the `withPseudoClass(String pseudoClass)` method.
 * If a custom pseudo-class is provided via `withPseudoClass`, the script will be created using that value.
 * If no pseudo-class is specified, the builders will fall back to the default values:
             - "actionScript" for `ActionScript`.
             - "modificationScript" for `ModificationScript`.
If we add a custom PseudoClass using the method `withPseudoClass(String pseudoClass)`, we need to specify a custom ExtensionClass for that custom pseudoClass
    
Example of custom extension for ActionScript:

```java
    @AutoService(ProjectFileExtension.class)
public class CustomActionScriptExtension extends ActionScriptExtension {
    @Override
    public String getProjectFilePseudoClass() {
           //this is the custom value specified using withPseudoClass(String pseudoClass) of ActionScriptBuilder
        return "customPseudoClass";
    }
}
```

Example of custom extension for ModificationScript:
```java
@AutoService(ProjectFileExtension.class)
public class CustomModificationScriptExtension extends ModificationScriptExtension {
    @Override
    public String getProjectFilePseudoClass() {
       //this is the custom value specified using withPseudoClass(String pseudoClass) of ModificationScriptBuilder
        return "customPseudoClass";  
    }
}
```


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
