### PR TITLE
Fix method more(Path) in AppData

### DIFF
--- a/afs-core/src/main/java/com/powsybl/afs/AppData.java
+++ b/afs-core/src/main/java/com/powsybl/afs/AppData.java
@@ -136,7 +136,7 @@ public class AppData implements AutoCloseable {
     }
 
     private static String[] more(String[] path) {
-        return path.length > 2 ? Arrays.copyOfRange(path, 2, path.length - 1) : new String[] {};
+        return path.length > 2 ? Arrays.copyOfRange(path, 2, path.length) : new String[] {};
     }
 
     private synchronized void loadFileSystems() {

--- a/afs-core/src/test/java/com/powsybl/afs/AppDataTest.java
+++ b/afs-core/src/test/java/com/powsybl/afs/AppDataTest.java
@@ -88,13 +88,13 @@ class AppDataTest {
         appData.addFileSystem(afs);
         afs.getRootFolder().createProject("test_project1");
         Folder testFolder = afs.getRootFolder().createFolder("test_folder");
-        testFolder.createFolder("test_folder2");
+        Folder testFolder2 = testFolder.createFolder("test_folder2");
         testFolder.createProject("test_project2");
 
         assertTrue(appData.getNode("mem:/").isPresent());
         assertTrue(appData.getNode("mem:/test_folder").isPresent());
         assertEquals(testFolder.getName(), appData.getNode("mem:/test_folder").get().getName());
         assertTrue(appData.getNode("mem:/test_folder:/test_folder2").isPresent());
-        assertEquals(testFolder.getName(), appData.getNode("mem:/test_folder:/test_folder2").get().getName());
+        assertEquals(testFolder2.getName(), appData.getNode("mem:/test_folder:/test_folder2").get().getName());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [ ] No

**What is the current behavior?**
In `AppData.more(String[] path)`, when the path contains at least two elements, the method returns a `String[]` containing the different elements starting from the index 2 and stopping at the index `length - 1`. The issue is that the last index is excluded so the last element is not returned.

**What is the new behavior (if this is a feature change)?**
The method now returns up to the index `length` so that the last element is also returned


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
