### PR TITLE
A script that is included multiple times should only be read once

### DIFF
--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/AbstractScript.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/AbstractScript.java
@@ -16,10 +16,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -105,12 +102,20 @@ public abstract class AbstractScript<T extends AbstractScript> extends ProjectFi
 
     @Override
     public String readScript(boolean withIncludes) {
+        return this.readScript(withIncludes, new HashSet<>());
+    }
+
+    private String readScript(boolean withIncludes, Set<String> visited) {
+        if (!visited.add(this.info.getId())) {
+            return "";
+        }
         String ownContent = readScript();
         if (withIncludes) {
             String includesScript = orderedDependencyManager
                 .getDependencies(INCLUDED_SCRIPTS_DEPENDENCY_NAME, AbstractScript.class)
                 .stream()
-                .map(script -> script.readScript(true))
+                .map(script -> script.readScript(true, visited))
+                .filter(StringUtils::isNotBlank)
                 .collect(Collectors.joining(DEFAULT_SCRIPTS_DELIMITER));
             if (StringUtils.isNotBlank(includesScript)) {
                 includesScript += DEFAULT_SCRIPTS_DELIMITER;

--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/AbstractScript.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/AbstractScript.java
@@ -102,20 +102,20 @@ public abstract class AbstractScript<T extends AbstractScript> extends ProjectFi
 
     @Override
     public String readScript(boolean withIncludes) {
-        return this.readScript(withIncludes, new HashSet<>());
+        Set<String> visitedScript = new HashSet<>();
+        visitedScript.add(info.getId());
+
+        return this.readScript(withIncludes, visitedScript);
     }
 
     private String readScript(boolean withIncludes, Set<String> visited) {
-        if (!visited.add(this.info.getId())) {
-            return "";
-        }
         String ownContent = readScript();
         if (withIncludes) {
             String includesScript = orderedDependencyManager
                 .getDependencies(INCLUDED_SCRIPTS_DEPENDENCY_NAME, AbstractScript.class)
                 .stream()
+                .filter(script -> visited.add(script.info.getId()))
                 .map(script -> script.readScript(true, visited))
-                .filter(StringUtils::isNotBlank)
                 .collect(Collectors.joining(DEFAULT_SCRIPTS_DELIMITER));
             if (StringUtils.isNotBlank(includesScript)) {
                 includesScript += DEFAULT_SCRIPTS_DELIMITER;

--- a/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/ModificationScriptTest.java
+++ b/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/ModificationScriptTest.java
@@ -175,10 +175,10 @@ class ModificationScriptTest extends AbstractProjectFileTest {
         String contentWithInclude = script.readScript(true);
         assertEquals("var foo=\"bar\"\n\nprintln 'bye'", contentWithInclude);
 
-        // Include it a second time
+        // Include it a second time -> read once
         script.addScript(include1);
         contentWithInclude = script.readScript(true);
-        assertEquals("var foo=\"bar\"\n\nvar foo=\"bar\"\n\nprintln 'bye'", contentWithInclude);
+        assertEquals("var foo=\"bar\"\n\nprintln 'bye'", contentWithInclude);
 
         // Remove the first and add it one time and then the second one
         script.removeScript(include1.getId());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
A script that is included several times is read multiple times


**What is the new behavior (if this is a feature change)?**
A script that is included several times is read once.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
