### PR TITLE
Keep extensions and context for a VirtualCase using another VirtualCase

### DIFF
--- a/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/LocalNetworkCacheService.java
+++ b/afs-ext-base/src/main/java/com/powsybl/afs/ext/base/LocalNetworkCacheService.java
@@ -74,7 +74,7 @@ public class LocalNetworkCacheService implements NetworkCacheService {
     private static ScriptResult<Network> loadNetworkFromVirtualCase(VirtualCase virtualCase, List<NetworkListener> listeners, Iterable<GroovyScriptExtension> extensions, Map<Class<?>, Object> contextObjects) {
         ProjectCase baseCase = (ProjectCase) virtualCase.getCase().orElseThrow(() -> new AfsException("Case link is dead"));
 
-        ScriptResult<Network> network = loadNetworkFromProjectCase(baseCase, listeners);
+        ScriptResult<Network> network = loadNetworkFromProjectCase(baseCase, listeners, extensions, contextObjects);
 
         if (network.getError() != null) {
             return network;
@@ -85,10 +85,6 @@ public class LocalNetworkCacheService implements NetworkCacheService {
         LOGGER.info("Applying script to network of project case {}", virtualCase.getId());
 
         return applyScript(network.getValue(), network.getOutput(), script, extensions, contextObjects);
-    }
-
-    private static ScriptResult<Network> loadNetworkFromProjectCase(ProjectCase projectCase, List<NetworkListener> listeners) {
-        return loadNetworkFromProjectCase(projectCase, listeners, Collections.emptyList(), Collections.emptyMap());
     }
 
     private static ScriptResult<Network> loadNetworkFromProjectCase(ProjectCase projectCase, Iterable<GroovyScriptExtension> extensions, Map<Class<?>, Object> contextObjects) {

--- a/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/VirtualCaseTest.java
+++ b/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/VirtualCaseTest.java
@@ -378,17 +378,17 @@ class VirtualCaseTest extends AbstractProjectFileTest {
             .withContent("customOut.write('-WORLD')")
             .build();
 
-        // Build the child virtual case
-        VirtualCase virtualCaseChild = folder.fileBuilder(VirtualCaseBuilder.class)
+        // Build the parent virtual case
+        VirtualCase virtualCaseParent = folder.fileBuilder(VirtualCaseBuilder.class)
             .withName("network2")
             .withCase(importedCase)
             .withScript(scriptHello)
             .build();
 
-        // Build the parent virtual case
-        VirtualCase virtualCaseParent = folder.fileBuilder(VirtualCaseBuilder.class)
+        // Build the child virtual case
+        VirtualCase virtualCaseChild = folder.fileBuilder(VirtualCaseBuilder.class)
             .withName("network3")
-            .withCase(virtualCaseChild)
+            .withCase(virtualCaseParent)
             .withScript(scriptWorld)
             .build();
         Iterable<GroovyScriptExtension> extensions = List.of(new CustomScriptTestExtension());
@@ -399,23 +399,23 @@ class VirtualCaseTest extends AbstractProjectFileTest {
         assertEquals(1, scriptHello.getBackwardDependencies().size());
         assertEquals(1, scriptWorld.getBackwardDependencies().size());
 
-        // Checks on the child virtual case
-        assertEquals("network2", virtualCaseChild.getName());
-        assertTrue(virtualCaseChild.getCase().isPresent());
-        assertTrue(virtualCaseChild.getScript().isPresent());
-        assertEquals(2, virtualCaseChild.getDependencies().size());
-        assertNotNull(virtualCaseChild.getNetwork(extensions, contextObjects));
-        assertFalse(virtualCaseChild.mandatoryDependenciesAreMissing());
-        assertEquals("HELLO", virtualCaseChild.getOutput());
-
         // Checks on the parent virtual case
-        assertEquals("network3", virtualCaseParent.getName());
+        assertEquals("network2", virtualCaseParent.getName());
         assertTrue(virtualCaseParent.getCase().isPresent());
         assertTrue(virtualCaseParent.getScript().isPresent());
         assertEquals(2, virtualCaseParent.getDependencies().size());
         assertNotNull(virtualCaseParent.getNetwork(extensions, contextObjects));
         assertFalse(virtualCaseParent.mandatoryDependenciesAreMissing());
-        assertEquals("HELLO-WORLD", virtualCaseParent.getOutput());
+        assertEquals("HELLO", virtualCaseParent.getOutput());
+
+        // Checks on the child virtual case
+        assertEquals("network3", virtualCaseChild.getName());
+        assertTrue(virtualCaseChild.getCase().isPresent());
+        assertTrue(virtualCaseChild.getScript().isPresent());
+        assertEquals(2, virtualCaseChild.getDependencies().size());
+        assertNotNull(virtualCaseChild.getNetwork(extensions, contextObjects));
+        assertFalse(virtualCaseChild.mandatoryDependenciesAreMissing());
+        assertEquals("HELLO-WORLD", virtualCaseChild.getOutput());
     }
 
 }

--- a/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/VirtualCaseTest.java
+++ b/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/VirtualCaseTest.java
@@ -32,10 +32,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -366,4 +363,59 @@ class VirtualCaseTest extends AbstractProjectFileTest {
         assertEquals("log from customOut", outputAfterInvalidate);
         assertEquals("", outputAfterInvalidateNoExtension);
     }
+
+    @Test
+    void buildingVirtualCaseInVirtualCaseTest() {
+        // create groovy script
+        ModificationScript scriptHello = folder.fileBuilder(ModificationScriptBuilder.class)
+            .withName("scriptHello")
+            .withType(ScriptType.GROOVY)
+            .withContent("customOut.write('HELLO')")
+            .build();
+        ModificationScript scriptWorld = folder.fileBuilder(ModificationScriptBuilder.class)
+            .withName("scriptWorld")
+            .withType(ScriptType.GROOVY)
+            .withContent("customOut.write('-WORLD')")
+            .build();
+
+        // Build the child virtual case
+        VirtualCase virtualCaseChild = folder.fileBuilder(VirtualCaseBuilder.class)
+            .withName("network2")
+            .withCase(importedCase)
+            .withScript(scriptHello)
+            .build();
+
+        // Build the parent virtual case
+        VirtualCase virtualCaseParent = folder.fileBuilder(VirtualCaseBuilder.class)
+            .withName("network3")
+            .withCase(virtualCaseChild)
+            .withScript(scriptWorld)
+            .build();
+        Iterable<GroovyScriptExtension> extensions = List.of(new CustomScriptTestExtension());
+        Map<Class<?>, Object> contextObjects = Map.of();
+
+        // Global checks
+        assertEquals(1, importedCase.getBackwardDependencies().size());
+        assertEquals(1, scriptHello.getBackwardDependencies().size());
+        assertEquals(1, scriptWorld.getBackwardDependencies().size());
+
+        // Checks on the child virtual case
+        assertEquals("network2", virtualCaseChild.getName());
+        assertTrue(virtualCaseChild.getCase().isPresent());
+        assertTrue(virtualCaseChild.getScript().isPresent());
+        assertEquals(2, virtualCaseChild.getDependencies().size());
+        assertNotNull(virtualCaseChild.getNetwork(extensions, contextObjects));
+        assertFalse(virtualCaseChild.mandatoryDependenciesAreMissing());
+        assertEquals("HELLO", virtualCaseChild.getOutput());
+
+        // Checks on the parent virtual case
+        assertEquals("network3", virtualCaseParent.getName());
+        assertTrue(virtualCaseParent.getCase().isPresent());
+        assertTrue(virtualCaseParent.getScript().isPresent());
+        assertEquals(2, virtualCaseParent.getDependencies().size());
+        assertNotNull(virtualCaseParent.getNetwork(extensions, contextObjects));
+        assertFalse(virtualCaseParent.mandatoryDependenciesAreMissing());
+        assertEquals("HELLO-WORLD", virtualCaseParent.getOutput());
+    }
+
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
If we set a virtualCase ("parent") that links to another virtualCase ("child") and then try to call the getNetwork() method then both the extensions and the contextMap will be empty when we call the getNetwork() for the "child" virtualCase


**What is the new behavior (if this is a feature change)?**
If we set a virtualCase ("parent") that links to another virtualCase ("child") and then try to call the getNetwork() method then the same extensions and contextMap are used for the "parent" and "child" virtualCase


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
