### PR TITLE
Replace uses of DefaultNetworkListener with NetworkListener

### DIFF
--- a/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/ImportedCaseTest.java
+++ b/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/ImportedCaseTest.java
@@ -25,7 +25,6 @@ import com.powsybl.afs.storage.AppStorage;
 import com.powsybl.afs.storage.InMemoryEventsBus;
 import com.powsybl.afs.storage.NodeGenericMetadata;
 import com.powsybl.afs.storage.NodeInfo;
-import com.powsybl.iidm.network.DefaultNetworkListener;
 import com.powsybl.iidm.network.ExportersLoader;
 import com.powsybl.iidm.network.ExportersLoaderList;
 import com.powsybl.iidm.network.ImportConfig;
@@ -171,7 +170,7 @@ class ImportedCaseTest extends AbstractProjectFileTest {
             .build();
 
         // Mock a listener
-        NetworkListener mockedListener = mock(DefaultNetworkListener.class);
+        NetworkListener mockedListener = mock(NetworkListener.class);
 
         // Get the network and add the listener to it
         assertNotNull(importedCase.getNetwork(Collections.singletonList(mockedListener)));

--- a/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/VirtualCaseTest.java
+++ b/afs-ext-base/src/test/java/com/powsybl/afs/ext/base/VirtualCaseTest.java
@@ -21,7 +21,6 @@ import com.powsybl.afs.storage.AppStorage;
 import com.powsybl.afs.storage.InMemoryEventsBus;
 import com.powsybl.afs.storage.NodeGenericMetadata;
 import com.powsybl.afs.storage.NodeInfo;
-import com.powsybl.iidm.network.DefaultNetworkListener;
 import com.powsybl.iidm.network.ImportConfig;
 import com.powsybl.iidm.network.ImportersLoader;
 import com.powsybl.iidm.network.ImportersLoaderList;
@@ -323,7 +322,7 @@ class VirtualCaseTest extends AbstractProjectFileTest {
             .withScript(scriptModif)
             .build();
 
-        NetworkListener mockedListener = mock(DefaultNetworkListener.class);
+        NetworkListener mockedListener = mock(NetworkListener.class);
         virtualCase.getNetwork(Collections.singletonList(mockedListener));
         verify(mockedListener, times(1))
             .onUpdate(network.getSubstation("s1"), "tso", null, "TSO", "tso_new");


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
See https://github.com/powsybl/powsybl-core/wiki/Migration-guide-v7.3.0#new-setid-method

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
